### PR TITLE
[10주차] 이민경_BE 과제 제출

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,7 @@ dependencies {
 	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
 	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 	implementation('commons-io:commons-io:2.11.0')
+	implementation 'org.modelmapper:modelmapper:2.3.9'
 
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,14 @@ dependencies {
 	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 	implementation('commons-io:commons-io:2.11.0')
 	implementation 'org.modelmapper:modelmapper:2.3.9'
+	// 템플릿 엔진 thymeleaf
+	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
+// 스프링 시큐리티
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+// 빈 유효성 검증
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'
+	testImplementation 'org.springframework.security:spring-security-test'
 
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,12 @@ dependencies {
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+	annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+	implementation('commons-io:commons-io:2.11.0')
+
 }
 
 tasks.named('bootBuildImage') {
@@ -36,4 +42,12 @@ tasks.named('bootBuildImage') {
 
 tasks.named('test') {
 	useJUnitPlatform()
+}
+def querydslDir = "$buildDir/generated/querydsl"
+
+sourceSets {
+	main.java.srcDir querydslDir
+}
+configurations {
+	querydsl.extendsFrom compileClasspath
 }

--- a/src/main/java/com/likelion12th/shop/Exception/OutOfStockException.java
+++ b/src/main/java/com/likelion12th/shop/Exception/OutOfStockException.java
@@ -1,0 +1,7 @@
+package com.likelion12th.shop.Exception;
+
+public class OutOfStockException extends RuntimeException{
+    public OutOfStockException (String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/likelion12th/shop/Service/CartService.java
+++ b/src/main/java/com/likelion12th/shop/Service/CartService.java
@@ -1,0 +1,115 @@
+package com.likelion12th.shop.Service;
+
+import com.likelion12th.shop.dto.CartDetailDto;
+import com.likelion12th.shop.dto.CartItemDto;
+import com.likelion12th.shop.dto.CartOrderDto;
+import com.likelion12th.shop.dto.OrderReqDto;
+import com.likelion12th.shop.entity.Cart;
+import com.likelion12th.shop.entity.CartItem;
+import com.likelion12th.shop.entity.Item;
+import com.likelion12th.shop.entity.Member;
+import com.likelion12th.shop.repository.CartItemRepository;
+import com.likelion12th.shop.repository.CartRepository;
+import com.likelion12th.shop.repository.ItemRepository;
+import com.likelion12th.shop.repository.MemberRepository;
+import jakarta.persistence.EntityNotFoundException;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service @Transactional @RequiredArgsConstructor //final이 붙은 필드를 자동으로 의존성 주입
+public class CartService {
+    private final CartRepository cartRepository;
+    private final CartItemRepository cartItemRepository;
+    private final ItemRepository itemRepository;
+    private final MemberRepository memberRepository;
+    private final OrderService orderService; //final을 안붙였더니 this.orderservice 오류 발생
+
+    public Long addCartItems(String email, List<CartItemDto> cartItemDtos) {
+        Member member = memberRepository.findByEmail(email);
+        if (member == null) {
+            Member newmember = new Member();
+            newmember.setEmail(email);
+            member = memberRepository.save(newmember);
+        }
+        Cart cart = cartRepository.findByMember(member);
+        if (cart == null) {
+            Cart newCart = cart.createCart(member);
+            cart=cartRepository.save(newCart);
+        }
+        Long saveItemId = null;
+        for (CartItemDto cartItemDto : cartItemDtos) {
+            Item item = itemRepository.findById(cartItemDto.getItemId())
+                    .orElseThrow(() -> new IllegalArgumentException("아이템 ID가 없음"));
+            CartItem saveCartItem = cartItemRepository.findByCartIdAndItemId(cart.getId(), item.getId());
+            if (saveCartItem != null) {
+                saveCartItem.addCount(cartItemDto.getCount());
+                saveItemId = saveCartItem.getId();
+            } else {
+                CartItem newItem = saveCartItem.createCartItem(cart, item, cartItemDto.getCount());
+                cartItemRepository.save(newItem);
+                saveItemId = newItem.getId();
+            }
+
+        }
+
+        return saveItemId;
+    }
+    public List<CartDetailDto> getCartList(String email){
+        List<CartDetailDto> cartDetailDtoList=new ArrayList<>();
+
+        Member member=memberRepository.findByEmail(email);
+        Cart cart =cartRepository.findByMember(member);
+        if (cart==null){
+            return cartDetailDtoList;
+        }
+        cartDetailDtoList=cartItemRepository.findCartOrderList(cart.getId());
+        return cartDetailDtoList;
+    }
+    public void deleteCartItem(String email, Long cartItemId){
+        CartItem cartItem=cartItemRepository.findById(cartItemId)
+                .orElseThrow(EntityNotFoundException::new);
+        if(!email.equals(cartItem.getCart().getMember().getEmail())){
+            throw new IllegalArgumentException();
+        }
+        cartItemRepository.delete(cartItem);
+    }
+    public void updateCartItemCount(String email, CartDetailDto cartDetailDto){
+        CartItem cartItem=cartItemRepository.findById(cartDetailDto.getCartItemId())
+                .orElseThrow(EntityNotFoundException::new);
+
+        if(!cartItem.getCart().getMember().getEmail().equals(email)){
+            throw new IllegalArgumentException();
+        }
+        cartItem.updateCount(cartDetailDto.getCount());
+    }
+    public Long orderCartItem(String email, List<CartOrderDto> cartOrderDtoList){//장바구니 주문+ 주문 시 장바구니 초기화
+        Member member=memberRepository.findByEmail(email);
+        if(member == null){
+            throw new EntityNotFoundException("사용자가 존재하지 않음 : "+ email);
+        }
+        Cart cart=cartRepository.findByMember(member);
+        if(cart==null){
+            throw new EntityNotFoundException("사용자의 장바구니가 존재하지 않음 : "+email);
+        }
+        List<OrderReqDto> orderDtoList=new ArrayList<>();
+        for(CartOrderDto cartOrderDto:cartOrderDtoList){
+            CartItem cartItem=cartItemRepository.findById(cartOrderDto.getCartItemId())
+                    .orElseThrow(EntityNotFoundException::new);  //장바구니 아이템 조회
+            OrderReqDto orderReqDto=new OrderReqDto();
+            orderReqDto.setItemId(cartItem.getItem().getId()); //cartitem의 아이디와 item 자체의 아이디는 다르다!!
+            orderReqDto.setCount(cartItem.getCount());
+            orderDtoList.add(orderReqDto);
+        }
+        Long orderId=orderService.orders(orderDtoList,email);
+        for(CartOrderDto cartOrderDto:cartOrderDtoList){//장바구니 초기화
+            CartItem cartItem=cartItemRepository.findById(cartOrderDto.getCartItemId())
+                    .orElseThrow(EntityNotFoundException::new);
+            cartItemRepository.delete(cartItem);
+        }
+        return orderId;
+    }
+}

--- a/src/main/java/com/likelion12th/shop/Service/ItemService.java
+++ b/src/main/java/com/likelion12th/shop/Service/ItemService.java
@@ -6,6 +6,7 @@ import com.likelion12th.shop.repository.ItemRepository;
 import com.likelion12th.shop.repository.MemberRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.hibernate.sql.Delete;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
@@ -64,4 +65,52 @@ public class ItemService {
             throw new HttpClientErrorException(HttpStatus.NOT_FOUND,"ID에 해당하는 상품을 찾을 수 없습니다."+ItemId);
         }
     }
+    public List<ItemFormDto>getItemByName(String itemName){
+        List<Item> items=itemRepository.findByItemNameContainingIgnoreCase(itemName);
+        List<ItemFormDto> itemFormDtos=new ArrayList<>();
+        items.forEach(s -> itemFormDtos.add(ItemFormDto.of(s)));
+        return itemFormDtos;
+    }
+    public void updateItem(Long itemId, ItemFormDto itemFormDto, MultipartFile itemImg)throws Exception{
+        Optional<Item> optionalItem=itemRepository.findById(itemId);
+        if(optionalItem.isPresent()){
+            Item item=optionalItem.get();
+            if(itemFormDto.getItemName()!=null){
+                item.setItemName(itemFormDto.getItemName());
+            }
+            if(itemFormDto.getPrice()!=null){
+                item.setPrice(itemFormDto.getPrice());
+            }
+            if(itemFormDto.getItemDetail() != null){
+                item.setItemDetail(itemFormDto.getItemDetail());
+            }
+            if(itemFormDto.getItemSellStatus()!=null){
+                item.setItemSellStatus(itemFormDto.getItemSellStatus());
+            }
+            if(itemFormDto.getStock()!=null){
+                item.setStock(itemFormDto.getStock());
+            }
+            if(itemImg!=null){
+                UUID uuid=UUID.randomUUID();
+                String fileName=uuid.toString()+"_"+itemImg.getOriginalFilename();
+                File itemImgFile=new File(uploadPath,fileName);
+                itemImg.transferTo(itemImgFile);
+                item.setItemImg(fileName);
+                item.setItemImgPath(uploadPath+"/"+fileName);
+            }
+            itemRepository.save(item);
+        }else{
+            throw new HttpClientErrorException(HttpStatus.NOT_FOUND,"ID에 해당하는 상품을 찾을 수 없습니다.");
+        }
+    }
+    public void deleteItem(Long itemId){
+        Optional<Item> optionalItem=itemRepository.findById(itemId);
+        if(optionalItem.isPresent()){
+            itemRepository.delete(optionalItem.get());
+        }else {
+            throw new HttpClientErrorException(HttpStatus.NOT_FOUND,"id에 해당하는 상품을 찾을 수 없습니다: "+itemId);
+        }
+
+    }
+
 }

--- a/src/main/java/com/likelion12th/shop/Service/ItemService.java
+++ b/src/main/java/com/likelion12th/shop/Service/ItemService.java
@@ -1,0 +1,67 @@
+package com.likelion12th.shop.Service;
+
+import com.likelion12th.shop.dto.ItemFormDto;
+import com.likelion12th.shop.entity.Item;
+import com.likelion12th.shop.repository.ItemRepository;
+import com.likelion12th.shop.repository.MemberRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ItemService {
+
+    @Autowired
+    private final ItemRepository itemRepository;
+
+    public Long saveItem(ItemFormDto itemFormDto) throws Exception{
+        Item item=itemFormDto.createItem();
+        itemRepository.save(item);
+
+        return item.getId();
+    }
+    @Value("${uploadPath}")
+    private String uploadPath;
+    public Long saveItem(ItemFormDto itemFormDto, MultipartFile itemImg) throws Exception{
+        Item item=itemFormDto.createItem();
+        UUID uuid =UUID.randomUUID();
+        String fileName=uuid.toString()+"_"+itemImg.getOriginalFilename();
+        File itemImgFile=new File(uploadPath,fileName);
+        itemImg.transferTo(itemImgFile);
+        item.setItemImg(fileName);
+        item.setItemImgPath(uploadPath+"/"+fileName);
+        itemRepository.save(item);
+
+        return item.getId();
+
+    }
+    public List<ItemFormDto> getItem(){
+        List<Item> items=itemRepository.findAll();
+        List<ItemFormDto> itemFormDtos=new ArrayList<>();
+        items.forEach(s -> itemFormDtos.add(ItemFormDto.of(s)));
+        return itemFormDtos;
+    }
+    public ItemFormDto getItemById(Long ItemId){
+        Optional<Item> optionalItem=itemRepository.findById(ItemId);
+
+        if(optionalItem.isPresent()){
+            return ItemFormDto.of(optionalItem.get());
+        }
+        else{
+            throw new HttpClientErrorException(HttpStatus.NOT_FOUND,"ID에 해당하는 상품을 찾을 수 없습니다."+ItemId);
+        }
+    }
+}

--- a/src/main/java/com/likelion12th/shop/Service/MemberService.java
+++ b/src/main/java/com/likelion12th/shop/Service/MemberService.java
@@ -1,0 +1,59 @@
+package com.likelion12th.shop.Service;
+
+import com.likelion12th.shop.constant.Role;
+import com.likelion12th.shop.entity.Member;
+import com.likelion12th.shop.repository.MemberRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.security.core.userdetails.UserDetailsService;
+
+import java.awt.*;
+import java.util.Objects;
+
+@Service
+@Transactional
+@RequiredArgsConstructor //의존성 주입 중 생성자 주입을 코드 없이 자동
+public class MemberService implements UserDetailsService{
+    private final MemberRepository memberRepository;
+
+    //회원가입
+    public void saveAdmin(Member member) {
+        member.setRole(Role.ADMIN);
+        if (Objects.equals(member.getRole().toString(), "ADMIN")) {
+            memberRepository.save(member);
+        }
+    }
+    public Member saveMember(Member member){
+        validateDuplicateMember(member);
+        return memberRepository.save(member); //save자체로 member를 반환
+    }
+
+
+    private void validateDuplicateMember(Member member) {
+        Member valiMember= memberRepository.findByEmail(member.getEmail());
+        if(valiMember!=null){
+            throw new IllegalStateException("이미 가입된 회원입니다. ");
+        }
+    }
+
+    @Override
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+
+        Member member = memberRepository.findByEmail(email);
+
+        if(member == null){
+            throw new UsernameNotFoundException(email);
+        }
+
+        return User.builder()
+                .username(member.getEmail())
+                .password(member.getPassword())
+                .roles(member.getRole().toString())
+                .build();
+    }
+
+}

--- a/src/main/java/com/likelion12th/shop/Service/MemberService.java
+++ b/src/main/java/com/likelion12th/shop/Service/MemberService.java
@@ -21,16 +21,16 @@ public class MemberService implements UserDetailsService{
     private final MemberRepository memberRepository;
 
     //회원가입
-    public void saveAdmin(Member member) {
+    public Member saveAdmin(Member member){
         member.setRole(Role.ADMIN);
-        if (Objects.equals(member.getRole().toString(), "ADMIN")) {
-            memberRepository.save(member);
-        }
+        validateDuplicateMember(member);
+        return memberRepository.save(member); //save자체로 member를 반환
     }
     public Member saveMember(Member member){
         validateDuplicateMember(member);
         return memberRepository.save(member); //save자체로 member를 반환
     }
+
 
 
     private void validateDuplicateMember(Member member) {

--- a/src/main/java/com/likelion12th/shop/Service/OrderService.java
+++ b/src/main/java/com/likelion12th/shop/Service/OrderService.java
@@ -1,0 +1,84 @@
+package com.likelion12th.shop.Service;
+
+import com.likelion12th.shop.dto.ItemFormDto;
+import com.likelion12th.shop.dto.OrderDto;
+import com.likelion12th.shop.dto.OrderItemDto;
+import com.likelion12th.shop.dto.OrderReqDto;
+import com.likelion12th.shop.entity.Item;
+import com.likelion12th.shop.entity.Member;
+import com.likelion12th.shop.entity.Order;
+import com.likelion12th.shop.entity.OrderItem;
+import com.likelion12th.shop.repository.ItemRepository;
+import com.likelion12th.shop.repository.MemberRepository;
+import com.likelion12th.shop.repository.OrderItemRepository;
+import com.likelion12th.shop.repository.OrderRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+@Service
+@RequiredArgsConstructor
+public class OrderService {
+    private final OrderRepository orderRepository;
+    private final MemberRepository memberRepository;
+    private final ItemRepository itemRepository;
+
+    public Long createNewOrder(OrderReqDto orderReqDto,String email ){
+        Member member=memberRepository.findByEmail(email);
+        if (member ==null){
+            Member newmember=new Member();
+            newmember.setEmail(email);
+            member = memberRepository.save(newmember);
+        }
+        Long itemId=orderReqDto.getItemId();
+        Item item=itemRepository.findById(itemId)
+                .orElseThrow(()->new IllegalArgumentException("상품 ID 없음 : "+itemId));
+        OrderItem orderItem=OrderItem.createOrderItem(item,orderReqDto.getCount());
+
+        List<OrderItem> orderItems=new ArrayList<>();
+        orderItems.add(orderItem);
+        Order order=Order.createOrder(member,orderItems);
+        orderRepository.save(order);
+
+        return order.getId();
+    }
+    public List<OrderDto>getAllOrdersByUserEmail(String email){
+        List<Order>orders=orderRepository.findByMemberEmail(email);
+        List<OrderDto> OrderDtos=new ArrayList<>();
+        orders.forEach(s -> OrderDtos.add(OrderDto.of(s)));
+
+        return OrderDtos;
+    }
+    public OrderItemDto getOrderDetails(Long orderId, String email){
+        Order order=orderRepository.findById(orderId)
+                .orElseThrow(()->new IllegalArgumentException("주문 ID 없음 : "+orderId));
+        if(!Objects.equals(order.getMember().getEmail(), email)){
+            throw new IllegalArgumentException("주문자만 접근 가능함");
+        }
+        List<OrderItem>orderItems=order.getOrderItemlist();
+        if(!orderItems.isEmpty()){
+            OrderItem orderItem=orderItems.get(0);
+
+
+            return OrderItemDto.of(orderItem);
+        }else {
+            throw new IllegalArgumentException("주문 아이템이 없음");
+        }
+    }
+    public void canelOrder(Long orderId, String email){
+        Order order=orderRepository.findById(orderId)
+                .orElseThrow(()->new IllegalArgumentException("주문 ID 없음 : "+orderId));
+        if(!order.getMember().getEmail().equals(email)){
+            throw new IllegalArgumentException("취소 권한이 없음");
+        }
+        //cancel로 주문 상태 변경, 재고 수량 증가
+        order.cancelOrder();
+
+        orderRepository.save(order);
+
+
+    }
+}

--- a/src/main/java/com/likelion12th/shop/Service/UserDetailsService.java
+++ b/src/main/java/com/likelion12th/shop/Service/UserDetailsService.java
@@ -1,0 +1,9 @@
+package com.likelion12th.shop.Service;
+
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsByNameServiceWrapper;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+
+public interface UserDetailsService {
+    UserDetails loadUserByUsername(String username)throws UsernameNotFoundException;
+}

--- a/src/main/java/com/likelion12th/shop/ShopApplication.java
+++ b/src/main/java/com/likelion12th/shop/ShopApplication.java
@@ -1,8 +1,10 @@
 package com.likelion12th.shop;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class ShopApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/likelion12th/shop/config/AuditConfig.java
+++ b/src/main/java/com/likelion12th/shop/config/AuditConfig.java
@@ -1,0 +1,14 @@
+package com.likelion12th.shop.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+public class AuditConfig {
+    @Bean
+    public AuditorAware<String> auditorProvider(){
+        return new AuditorAwareImpl();
+    }
+}

--- a/src/main/java/com/likelion12th/shop/config/AuditorAwareImpl.java
+++ b/src/main/java/com/likelion12th/shop/config/AuditorAwareImpl.java
@@ -1,0 +1,21 @@
+package com.likelion12th.shop.config;
+
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.util.Optional;
+
+public class AuditorAwareImpl implements AuditorAware<String> {
+    @Override
+    public Optional<String> getCurrentAuditor(){
+        Authentication authentication= SecurityContextHolder.getContext().getAuthentication();
+
+        String userId="";
+        if(authentication != null){
+            userId=authentication.getName();
+        }
+        return Optional.of(userId);
+    }
+
+}

--- a/src/main/java/com/likelion12th/shop/config/CustomAccessDeniedHandle.java
+++ b/src/main/java/com/likelion12th/shop/config/CustomAccessDeniedHandle.java
@@ -1,0 +1,20 @@
+package com.likelion12th.shop.config;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+
+import java.io.IOException;
+
+public class CustomAccessDeniedHandle implements AccessDeniedHandler {
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException, ServletException {
+        response.sendError(HttpServletResponse.SC_FORBIDDEN, "관리자만 접근할 수 있는 페이지입니다.");
+
+    }
+}

--- a/src/main/java/com/likelion12th/shop/config/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/likelion12th/shop/config/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,21 @@
+package com.likelion12th.shop.config;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+
+import java.io.IOException;
+
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException)
+            throws IOException, ServletException {
+        if ("XMLHttpRequest".equals(request.getHeader("x-requested-with"))) {
+            response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Unauthorized"); //401오류 반환
+        } else {
+            response.sendRedirect("/members/login");//일반 요청을 보낸 경우 로그인 페이지로 이동
+        }
+    }
+}

--- a/src/main/java/com/likelion12th/shop/config/SecurityConfig.java
+++ b/src/main/java/com/likelion12th/shop/config/SecurityConfig.java
@@ -1,0 +1,67 @@
+package com.likelion12th.shop.config;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.AllArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+
+import java.io.IOException;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .formLogin(form -> form
+                        .loginPage("/members/login")
+                        .defaultSuccessUrl("/")
+                        .usernameParameter("email")
+                        .passwordParameter("password")
+                        .failureUrl("/members/login/error")
+                )
+
+                .logout(logout -> logout
+                        .logoutRequestMatcher(new AntPathRequestMatcher("/members/logout"))
+                        .logoutSuccessUrl("/")
+                        .permitAll()
+                );
+
+        // 보안검사
+        http
+                .csrf(AbstractHttpConfigurer::disable
+                )
+                .authorizeHttpRequests(requests -> requests
+                        .requestMatchers("/members/login").anonymous()
+                        .requestMatchers("/members/logout").authenticated()
+                        .requestMatchers("/admin/**").hasRole("ADMIN")
+                        .anyRequest().permitAll()
+
+                );
+
+        // 인증 실패시 대처 방법 커스텀
+        http
+                .exceptionHandling(error -> error
+                        .authenticationEntryPoint(new CustomAuthenticationEntryPoint())
+                        .accessDeniedHandler(new CustomAccessDeniedHandle())
+
+                );
+
+        return http.build();
+    }
+}

--- a/src/main/java/com/likelion12th/shop/constant/OrderStatus.java
+++ b/src/main/java/com/likelion12th/shop/constant/OrderStatus.java
@@ -1,0 +1,5 @@
+package com.likelion12th.shop.constant;
+
+public enum OrderStatus {
+    CANCEL,ORDER
+}

--- a/src/main/java/com/likelion12th/shop/constant/Role.java
+++ b/src/main/java/com/likelion12th/shop/constant/Role.java
@@ -1,0 +1,5 @@
+package com.likelion12th.shop.constant;
+
+public enum Role {
+    USER,ADMIN;
+}

--- a/src/main/java/com/likelion12th/shop/constant/SellStatus.java
+++ b/src/main/java/com/likelion12th/shop/constant/SellStatus.java
@@ -1,0 +1,5 @@
+package com.likelion12th.shop.constant;
+
+public enum SellStatus {
+    SELL,SOLDOUT;
+}

--- a/src/main/java/com/likelion12th/shop/controller/AdminController.java
+++ b/src/main/java/com/likelion12th/shop/controller/AdminController.java
@@ -1,0 +1,27 @@
+package com.likelion12th.shop.controller;
+
+import com.likelion12th.shop.Service.MemberService;
+import com.likelion12th.shop.dto.MemberFormDto;
+import com.likelion12th.shop.entity.Member;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.security.crypto.password.PasswordEncoder;
+@RequestMapping("/admin")
+@Controller
+@RequiredArgsConstructor
+public class AdminController {
+
+    @GetMapping("/page")
+    public String adminPage() {
+        return "member/admin";
+    }
+
+
+
+}

--- a/src/main/java/com/likelion12th/shop/controller/CartController.java
+++ b/src/main/java/com/likelion12th/shop/controller/CartController.java
@@ -1,0 +1,64 @@
+package com.likelion12th.shop.controller;
+
+import com.likelion12th.shop.Service.CartService;
+import com.likelion12th.shop.dto.CartDetailDto;
+import com.likelion12th.shop.dto.CartItemDto;
+import com.likelion12th.shop.dto.CartOrderDto;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.hibernate.action.internal.EntityActionVetoException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/cart")
+public class CartController {
+    private final CartService cartService;
+
+    @PostMapping("/add")
+    public ResponseEntity<String> addCartItems(@RequestParam String email, @RequestBody List<CartItemDto> cartItemDtos){
+        cartService.addCartItems(email,cartItemDtos);
+        return ResponseEntity.ok("장바구니에 상품을 담았음");
+    }
+    @GetMapping
+    public ResponseEntity<List<CartDetailDto>> getCart(@RequestParam String email){
+        List<CartDetailDto> cartDetailDto=cartService.getCartList(email);
+        return ResponseEntity.ok(cartDetailDto);
+    }
+    @DeleteMapping("/{cartItemId}")
+    public ResponseEntity<String> deleteCartItem(@RequestParam String email, @PathVariable Long cartItemId){
+        try{
+            cartService.deleteCartItem(email,cartItemId);
+            return ResponseEntity.ok("장바구니에서 상품 삭제됨: "+ cartItemId);
+        }catch (EntityActionVetoException e){
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body("해당 상품 ID 없음 : "+cartItemId);
+        }catch (IllegalArgumentException e){
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).body("해당 사용자의 장바구니에 없는 상품임");
+        }
+    }
+    @PatchMapping("")
+    public ResponseEntity<String> updateCartItemCount(@RequestParam String email, @RequestBody CartDetailDto cartDetailDto){
+        try{
+            cartService.updateCartItemCount(email,cartDetailDto);
+            return ResponseEntity.ok("상품 ID : "+cartDetailDto.getCartItemId()+ ", 수량 : "+cartDetailDto.getCount());
+        }catch (EntityNotFoundException e){
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body("해당 상품 ID가 없음.");
+        }catch (IllegalArgumentException e){
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).body("해당 사용자의 장바구니에 없는 상품임.");
+        }
+    }
+    @PostMapping("/orders")
+    public ResponseEntity<String> orderCartItem(@RequestParam String email, @RequestBody CartOrderDto cartOrderDto){
+        List<CartOrderDto> cartOrderDtoList=cartOrderDto.getCartOrderDtoList();
+        try {
+            Long orderId= cartService.orderCartItem(email, cartOrderDtoList); //장바구니에서 주문 생성
+            return ResponseEntity.ok("사용자 : "+email+", 주문 ID: "+orderId);
+        }catch (Exception e){
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("주문 실패 : "+e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/likelion12th/shop/controller/ItemController.java
+++ b/src/main/java/com/likelion12th/shop/controller/ItemController.java
@@ -1,0 +1,59 @@
+package com.likelion12th.shop.controller;
+
+import com.likelion12th.shop.Service.ItemService;
+import com.likelion12th.shop.dto.ItemFormDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/item")
+@RequiredArgsConstructor
+public class ItemController {
+    private final ItemService itemService;
+
+
+    @PostMapping("/new")
+    public ResponseEntity<Long> createItem(@RequestPart(name = "itemFormDto") ItemFormDto itemFormDto,
+                                           @RequestPart(value = "itemImg", required = false) MultipartFile itemImg) {
+        if (itemImg == null)//itemImg가 비어있는 경우
+        {
+            try {
+                Long itemId = itemService.saveItem(itemFormDto);
+                return ResponseEntity.status(HttpStatus.CREATED).body(itemId);
+            } catch (Exception e) {
+                return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+            }
+
+        } else {
+            try {
+                Long itemId = itemService.saveItem(itemFormDto, itemImg);
+                return ResponseEntity.status(HttpStatus.CREATED).body(itemId);
+            } catch (Exception e) {
+                return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+            }
+        }
+
+    }
+    @GetMapping
+    public ResponseEntity<List<ItemFormDto>> getItems(){
+        return ResponseEntity.ok().body(itemService.getItem());
+    }
+    @GetMapping("/{itemId}")
+    public ResponseEntity<ItemFormDto> getItemById(@PathVariable Long itemId){
+        try {
+            ItemFormDto itemFormDto=itemService.getItemById(itemId);
+            return ResponseEntity.ok().body(itemFormDto);
+        }catch (HttpClientErrorException e){
+            return ResponseEntity.status(e.getStatusCode()).body(null);
+        }catch (Exception e){
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
+    }
+
+}

--- a/src/main/java/com/likelion12th/shop/controller/ItemController.java
+++ b/src/main/java/com/likelion12th/shop/controller/ItemController.java
@@ -55,5 +55,41 @@ public class ItemController {
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
         }
     }
+    @GetMapping("/search")
+    public ResponseEntity<List<ItemFormDto>> searchItemsByName(@RequestParam("itemName") String itemName){
+        try {
+            List<ItemFormDto> itemFormDtos=itemService.getItemByName(itemName);
+
+            return ResponseEntity.ok().body(itemFormDtos);
+        }catch (Exception e){
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
+
+    }
+    @PatchMapping("/{itemId}")
+    public ResponseEntity<String>updateItem(@PathVariable("itemId")Long itemId,
+                                          @RequestPart(name = "itemFormDto") ItemFormDto itemFormDto,
+                                          @RequestPart(value = "itemImg", required = false) MultipartFile itemImg){
+        try{
+            itemService.updateItem(itemId,itemFormDto,itemImg);
+            return ResponseEntity.ok().body("상품이 성공적으로 수정되었습니다.");
+        }catch (HttpClientErrorException e){
+            return ResponseEntity.status(e.getStatusCode()).body("상품을 찾을 수 없습니다.");
+        }catch (Exception e){
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
+
+    }
+    @DeleteMapping("/{itemId}")
+    public ResponseEntity<String>deleteItem(@PathVariable("itemId")Long itemId){
+        try {
+            itemService.deleteItem(itemId);
+            return ResponseEntity.ok().body("상품이 성공적으로 삭제되었습니다.");
+        }catch (HttpClientErrorException e){
+            return ResponseEntity.status(e.getStatusCode()).body("상품을 찾을 수 없습니다.");
+        }catch (Exception e){
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
+    }
 
 }

--- a/src/main/java/com/likelion12th/shop/controller/MainController.java
+++ b/src/main/java/com/likelion12th/shop/controller/MainController.java
@@ -1,0 +1,16 @@
+package com.likelion12th.shop.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+@RequiredArgsConstructor
+public class MainController {
+    @GetMapping(value = "/")
+    public String main(){
+        return "main";
+    }
+
+
+}

--- a/src/main/java/com/likelion12th/shop/controller/MemberController.java
+++ b/src/main/java/com/likelion12th/shop/controller/MemberController.java
@@ -1,0 +1,85 @@
+package com.likelion12th.shop.controller;
+
+
+import com.likelion12th.shop.Service.MemberService;
+import com.likelion12th.shop.constant.Role;
+import com.likelion12th.shop.dto.MemberFormDto;
+import com.likelion12th.shop.entity.Member;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+
+@RequestMapping("/members")
+@Controller
+@RequiredArgsConstructor
+public class MemberController {
+
+    private final MemberService memberService;
+    private final PasswordEncoder passwordEncoder;
+
+    // 요청 시 회원가입 폼 페이지로 이동
+    @GetMapping(value = "/new")
+    public String memberForm(Model model) {
+        model.addAttribute("memberFormDto", new MemberFormDto());
+        return "member/memberForm";
+    }
+
+    // submit 버튼 누르면 호출되어 회원 생성
+    @PostMapping(value = "/new")
+    public String memberForm(@Valid MemberFormDto memberFormDto, BindingResult bindingResult, Model model) {
+        if (bindingResult.hasErrors()) {
+            System.out.println("error발생");
+            return "member/memberForm";
+        }
+        try {
+            Member member = Member.createMember(memberFormDto, passwordEncoder);
+            memberService.saveMember(member);
+        } catch (IllegalStateException e) {
+            model.addAttribute("errorMessage", e.getMessage());
+            return "member/memberForm";
+        }
+        return "redirect:/";
+    }
+    @GetMapping("/login")
+    public String loginMember(){return "/member/memberLoginForm";}
+
+    @GetMapping("/login/error")
+    public String loginError(Model model){
+        model.addAttribute("loginErrorMsg","아이디 또는 비밀번호를 확인해주세요.");
+        return "/member/memberLoginForm";
+
+    }
+    @GetMapping(value = "/adminnew")
+    public String adminMemberForm(Model model) {
+        model.addAttribute("memberFormDto", new MemberFormDto());
+        return "member/memberForm";
+    }
+
+    // submit 버튼 누르면 호출되어 회원 생성
+    @PostMapping(value = "/adminnew")
+    public String adminMemberForm(@Valid MemberFormDto memberFormDto, BindingResult bindingResult, Model model) {
+        if (bindingResult.hasErrors()) {
+            System.out.println("error발생");
+            return "member/memberForm";
+        }
+        try {
+            Member admin = Member.createAdmin(memberFormDto, passwordEncoder);
+            admin.setRole(Role.ADMIN);
+            memberService.saveAdmin(admin);
+        } catch (IllegalStateException e) {
+            model.addAttribute("errorMessage", e.getMessage());
+            return "member/memberForm";
+        }
+        return "redirect:/";
+    }
+
+
+
+}

--- a/src/main/java/com/likelion12th/shop/controller/MemberController.java
+++ b/src/main/java/com/likelion12th/shop/controller/MemberController.java
@@ -71,7 +71,6 @@ public class MemberController {
         }
         try {
             Member admin = Member.createAdmin(memberFormDto, passwordEncoder);
-            admin.setRole(Role.ADMIN);
             memberService.saveAdmin(admin);
         } catch (IllegalStateException e) {
             model.addAttribute("errorMessage", e.getMessage());

--- a/src/main/java/com/likelion12th/shop/controller/OrderController.java
+++ b/src/main/java/com/likelion12th/shop/controller/OrderController.java
@@ -1,0 +1,50 @@
+package com.likelion12th.shop.controller;
+
+import com.likelion12th.shop.Service.OrderService;
+import com.likelion12th.shop.dto.ItemFormDto;
+import com.likelion12th.shop.dto.OrderDto;
+import com.likelion12th.shop.dto.OrderItemDto;
+import com.likelion12th.shop.dto.OrderReqDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController @RequiredArgsConstructor @RequestMapping("api/orders")
+public class OrderController {
+    private final OrderService orderService;
+
+    @PostMapping("/new")
+    public ResponseEntity<String>createNewOrder(@RequestPart(name = "orderReqDto")OrderReqDto orderReqDto,
+                                                @RequestParam("email") String email){
+        try{
+            Long orderId=orderService.createNewOrder(orderReqDto,email);
+            return ResponseEntity.ok("사용자: "+email+", 주문 ID: "+orderId);
+        }catch (Exception e){
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("주문 실패 : "+e.getMessage());
+        }
+
+    }
+    @GetMapping("/all")
+    public ResponseEntity<List<OrderDto>>getAllOrderByUserEmail(@RequestParam("email") String email){
+        List<OrderDto>orders=orderService.getAllOrdersByUserEmail(email);
+        return ResponseEntity.ok(orders);
+    }
+    @GetMapping("/{orderId}")
+    public ResponseEntity<OrderItemDto> getOrderDetails(@PathVariable("orderId") Long orderId,@RequestParam("email") String email){
+        OrderItemDto orderItemDto=orderService.getOrderDetails(orderId,email);
+        return ResponseEntity.ok(orderItemDto);
+    }
+
+    @GetMapping("/{orderId}/cancel")
+    public ResponseEntity<String>cancelOrder(@PathVariable("orderId") Long orderId,@RequestParam("email") String email){
+        try {
+            orderService.canelOrder(orderId,email);
+            return ResponseEntity.ok("주문이 취소되었습니다.");
+        }catch (Exception e){
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("주문 취소 실패: "+e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/likelion12th/shop/controller/OrderController.java
+++ b/src/main/java/com/likelion12th/shop/controller/OrderController.java
@@ -33,9 +33,9 @@ public class OrderController {
         return ResponseEntity.ok(orders);
     }
     @GetMapping("/{orderId}")
-    public ResponseEntity<OrderItemDto> getOrderDetails(@PathVariable("orderId") Long orderId,@RequestParam("email") String email){
-        OrderItemDto orderItemDto=orderService.getOrderDetails(orderId,email);
-        return ResponseEntity.ok(orderItemDto);
+    public ResponseEntity<List<OrderItemDto>> getOrderDetails(@PathVariable("orderId") Long orderId,@RequestParam("email") String email){
+        List<OrderItemDto> orderItemDtos=orderService.getOrderDetails(orderId,email);
+        return ResponseEntity.ok(orderItemDtos);
     }
 
     @GetMapping("/{orderId}/cancel")

--- a/src/main/java/com/likelion12th/shop/dto/CartDetailDto.java
+++ b/src/main/java/com/likelion12th/shop/dto/CartDetailDto.java
@@ -1,0 +1,23 @@
+package com.likelion12th.shop.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter @Setter @NoArgsConstructor
+//역할: 어노테이션으로 기본 생성자 자동 추가 수량 변경 시 일부 필드만 포함하는 json데이터로부터 객체를 생성해야하기 때문에 기본 생성자 필요
+public class CartDetailDto {
+    private Long cartItemId;
+    private String itemName;
+    private int itemPrice;
+    private int count;
+    private String itemImgPath;
+
+    public CartDetailDto(Long cartItemId, String itemName, int itemPrice, int count, String itemImgPath){
+        this.cartItemId=cartItemId;
+        this.itemName=itemName;
+        this.itemPrice=itemPrice;
+        this.count=count;
+        this.itemImgPath=itemImgPath;
+    }
+}

--- a/src/main/java/com/likelion12th/shop/dto/CartItemDto.java
+++ b/src/main/java/com/likelion12th/shop/dto/CartItemDto.java
@@ -1,0 +1,11 @@
+package com.likelion12th.shop.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class CartItemDto {
+    private Long itemId;
+    private int count;
+}

--- a/src/main/java/com/likelion12th/shop/dto/CartOrderDto.java
+++ b/src/main/java/com/likelion12th/shop/dto/CartOrderDto.java
@@ -1,0 +1,12 @@
+package com.likelion12th.shop.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter @Setter
+public class CartOrderDto {
+    private Long cartItemId;
+    private List<CartOrderDto> cartOrderDtoList;
+}

--- a/src/main/java/com/likelion12th/shop/dto/ItemFormDto.java
+++ b/src/main/java/com/likelion12th/shop/dto/ItemFormDto.java
@@ -1,0 +1,18 @@
+package com.likelion12th.shop.dto;
+
+import com.likelion12th.shop.constant.SellStatus;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter @Setter
+public class ItemFormDto {
+    private String itemName;
+    private String price;
+    private Integer stock;
+    private String itemDetail;
+
+    @Enumerated(EnumType.STRING)
+    private SellStatus itemSellStatus;
+}

--- a/src/main/java/com/likelion12th/shop/dto/ItemFormDto.java
+++ b/src/main/java/com/likelion12th/shop/dto/ItemFormDto.java
@@ -1,18 +1,37 @@
 package com.likelion12th.shop.dto;
 
 import com.likelion12th.shop.constant.SellStatus;
+import com.likelion12th.shop.entity.Item;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import lombok.Getter;
 import lombok.Setter;
+import org.antlr.v4.runtime.misc.NotNull;
+import org.modelmapper.ModelMapper;
+
 
 @Getter @Setter
 public class ItemFormDto {
-    private String itemName;
-    private String price;
-    private Integer stock;
-    private String itemDetail;
 
-    @Enumerated(EnumType.STRING)
+    private  Long id;
+    @NotNull
+    private String itemName;
+    @NotNull
+    private Integer price;
+    @NotNull
+    private String itemDetail;
+    @NotNull
+    private Integer stock;
+    @NotNull
     private SellStatus itemSellStatus;
+
+    private static ModelMapper modelMapper = new ModelMapper();
+    // Dto -> 엔티티 객체 변환을 위한 메서드
+    public Item createItem(){
+        return modelMapper.map(this, Item.class);
+    }
+
+    public static ItemFormDto of(Item item){
+        return modelMapper.map(item,ItemFormDto.class);
+    }
 }

--- a/src/main/java/com/likelion12th/shop/dto/MemberFormDto.java
+++ b/src/main/java/com/likelion12th/shop/dto/MemberFormDto.java
@@ -1,12 +1,24 @@
 package com.likelion12th.shop.dto;
 
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 import lombok.Setter;
+import org.hibernate.validator.constraints.Length;
 
 @Getter @Setter
 public class MemberFormDto {
+    @NotBlank(message = "이름은 필수 입력 값입니다.")
     private String name;
+
+    @NotBlank(message = "이메일은 필수 입력 값입니다.")
+    @Email(message = "이메일 형식으로 입력하세요.")
     private String email;
+
+    @NotBlank(message = "비밀번호는 필수 입력 값입니다.")
+    @Length(min=8, max = 16, message = "비밀번호는 8자 이상, 16자 이하로 입력하세요.")
     private String password;
+
+    @NotBlank(message = "주소는 필수 입력 값입니다.")
     private String address;
 }

--- a/src/main/java/com/likelion12th/shop/dto/MemberFormDto.java
+++ b/src/main/java/com/likelion12th/shop/dto/MemberFormDto.java
@@ -1,0 +1,12 @@
+package com.likelion12th.shop.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter @Setter
+public class MemberFormDto {
+    private String name;
+    private String email;
+    private String password;
+    private String address;
+}

--- a/src/main/java/com/likelion12th/shop/dto/OrderDto.java
+++ b/src/main/java/com/likelion12th/shop/dto/OrderDto.java
@@ -7,21 +7,30 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.modelmapper.ModelMapper;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 @Getter @Setter @NoArgsConstructor
 public class OrderDto {
     private Long orderId;
     private String orderDate;
     private OrderStatus orderStatus;
-    private Long itemId;
+    private List<Long> itemIds; // 여러 아이템 ID
     private int totalPrice;
 
     private static ModelMapper modelMapper=new ModelMapper();
 
     public static OrderDto of(Order order){
         OrderDto orderDto=modelMapper.map(order, OrderDto.class);
-        if(!order.getOrderItemlist().isEmpty()){
-            orderDto.setItemId(order.getOrderItemlist().get(0).getItem().getId());
-        }
+        // Order 객체의 orderItemList를 스트림의 변환하고,
+        // orderDto의 itemIds 필드에 설정
+        orderDto.setItemIds(order.getOrderItemlist().stream()
+                // orderItem 객체에서 itemId 추출
+                .map(orderItem -> orderItem.getItem().getId())
+                // itemId를 리스트로
+                .collect(Collectors.toList()));
         return orderDto;
     }
+
+
 }

--- a/src/main/java/com/likelion12th/shop/dto/OrderDto.java
+++ b/src/main/java/com/likelion12th/shop/dto/OrderDto.java
@@ -1,0 +1,27 @@
+package com.likelion12th.shop.dto;
+
+import com.likelion12th.shop.constant.OrderStatus;
+import com.likelion12th.shop.entity.Order;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.modelmapper.ModelMapper;
+
+@Getter @Setter @NoArgsConstructor
+public class OrderDto {
+    private Long orderId;
+    private String orderDate;
+    private OrderStatus orderStatus;
+    private Long itemId;
+    private int totalPrice;
+
+    private static ModelMapper modelMapper=new ModelMapper();
+
+    public static OrderDto of(Order order){
+        OrderDto orderDto=modelMapper.map(order, OrderDto.class);
+        if(!order.getOrderItemlist().isEmpty()){
+            orderDto.setItemId(order.getOrderItemlist().get(0).getItem().getId());
+        }
+        return orderDto;
+    }
+}

--- a/src/main/java/com/likelion12th/shop/dto/OrderItemDto.java
+++ b/src/main/java/com/likelion12th/shop/dto/OrderItemDto.java
@@ -1,0 +1,22 @@
+package com.likelion12th.shop.dto;
+
+import com.likelion12th.shop.entity.Item;
+import com.likelion12th.shop.entity.OrderItem;
+import lombok.Getter;
+import lombok.Setter;
+import org.modelmapper.ModelMapper;
+
+@Getter @Setter
+public class OrderItemDto {
+    private Long itemId;
+    private String ItemName;
+    private Integer itemPrice;
+    private Integer count;
+    private int totalPrice;
+
+    private static ModelMapper modelMapper=new ModelMapper();
+
+    public static OrderItemDto of(OrderItem orderItem){
+        return modelMapper.map(orderItem,OrderItemDto.class);
+    }
+}

--- a/src/main/java/com/likelion12th/shop/dto/OrderReqDto.java
+++ b/src/main/java/com/likelion12th/shop/dto/OrderReqDto.java
@@ -1,0 +1,10 @@
+package com.likelion12th.shop.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter @Setter
+public class OrderReqDto {
+    private Long itemId;
+    private Integer count;
+}

--- a/src/main/java/com/likelion12th/shop/dto/ReviewFormDto.java
+++ b/src/main/java/com/likelion12th/shop/dto/ReviewFormDto.java
@@ -1,0 +1,8 @@
+package com.likelion12th.shop.dto;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter @Setter
+public class ReviewFormDto {
+    private String content;
+}

--- a/src/main/java/com/likelion12th/shop/entity/Base.java
+++ b/src/main/java/com/likelion12th/shop/entity/Base.java
@@ -1,0 +1,22 @@
+package com.likelion12th.shop.entity;
+
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@EntityListeners(value={AuditingEntityListener.class})
+@MappedSuperclass
+@Getter
+public abstract class Base extends BaseTime{
+    @CreatedBy
+    @Column(updatable = false) // 수정불가
+    private String createdBy;
+
+    @LastModifiedBy
+    private String modifiedBy;
+}

--- a/src/main/java/com/likelion12th/shop/entity/BaseTime.java
+++ b/src/main/java/com/likelion12th/shop/entity/BaseTime.java
@@ -1,0 +1,25 @@
+package com.likelion12th.shop.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@EntityListeners(value = {AuditingEntityListener.class})
+@MappedSuperclass
+@Getter @Setter
+public abstract class BaseTime {
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime regTime;
+
+    @LastModifiedDate
+    @Column(updatable = false)
+    private LocalDateTime updateTime;
+}

--- a/src/main/java/com/likelion12th/shop/entity/Cart.java
+++ b/src/main/java/com/likelion12th/shop/entity/Cart.java
@@ -1,4 +1,25 @@
 package com.likelion12th.shop.entity;
 
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "cart")
+@Getter
 public class Cart {
+    @Id
+    @Column(name = "cart_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne
+    @JoinColumn(name="member_id")
+    private Member member;
+    private LocalDateTime createdBy;
+    private LocalDateTime modifiedBy;
+
+
 }

--- a/src/main/java/com/likelion12th/shop/entity/Cart.java
+++ b/src/main/java/com/likelion12th/shop/entity/Cart.java
@@ -8,7 +8,7 @@ import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "cart")
-@Getter
+@Getter @Setter
 public class Cart {
     @Id
     @Column(name = "cart_id")
@@ -20,6 +20,12 @@ public class Cart {
     private Member member;
     private LocalDateTime createdBy;
     private LocalDateTime modifiedBy;
+
+    public static Cart createCart(Member member){
+        Cart cart=new Cart();
+        cart.setMember(member);
+        return cart;
+    }
 
 
 }

--- a/src/main/java/com/likelion12th/shop/entity/CartItem.java
+++ b/src/main/java/com/likelion12th/shop/entity/CartItem.java
@@ -1,12 +1,13 @@
 package com.likelion12th.shop.entity;
 import jakarta.persistence.*;
 import lombok.Getter;
+import lombok.Setter;
 
 import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "cart_item")
-@Getter
+@Getter @Setter
 public class CartItem {
     @Id
     @Column(name = "cartitem_id")
@@ -24,6 +25,21 @@ public class CartItem {
     private Integer count;
     private LocalDateTime createdBy;
     private LocalDateTime modifiedBy;
+
+    public static CartItem createCartItem(Cart cart,Item item, int count){
+        CartItem cartItem=new CartItem();
+        cartItem.setCart(cart);
+        cartItem.setItem(item);
+        cartItem.setCount(count);
+
+        return cartItem;
+    }
+    public void addCount(int count){
+        this.count+=count;
+    }
+    public void updateCount(int count){
+        this.count=count;
+    }
 
 
 }

--- a/src/main/java/com/likelion12th/shop/entity/CartItem.java
+++ b/src/main/java/com/likelion12th/shop/entity/CartItem.java
@@ -1,4 +1,29 @@
 package com.likelion12th.shop.entity;
+import jakarta.persistence.*;
+import lombok.Getter;
 
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "cart_item")
+@Getter
 public class CartItem {
+    @Id
+    @Column(name = "cartitem_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name="item_id")
+    private Item item;
+
+    @ManyToOne
+    @JoinColumn(name="cart_id")
+    private Cart cart;
+
+    private Integer count;
+    private LocalDateTime createdBy;
+    private LocalDateTime modifiedBy;
+
+
 }

--- a/src/main/java/com/likelion12th/shop/entity/Item.java
+++ b/src/main/java/com/likelion12th/shop/entity/Item.java
@@ -2,14 +2,18 @@ package com.likelion12th.shop.entity;
 
 
 import com.likelion12th.shop.constant.SellStatus;
+import com.likelion12th.shop.repository.ItemRepository;
 import jakarta.persistence.*;
 import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+import org.antlr.v4.runtime.misc.LogManager;
 
 import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "item")
-@Getter
+@Getter @Setter @ToString
 public class Item {
     @Id
     @Column(name = "item_id")
@@ -25,5 +29,10 @@ public class Item {
     private SellStatus itemSellStatus;
     private LocalDateTime createdBy;
     private LocalDateTime modifiedBy;
+
+    private String itemImg;
+    private String itemImgPath;
+
+
 
 }

--- a/src/main/java/com/likelion12th/shop/entity/Item.java
+++ b/src/main/java/com/likelion12th/shop/entity/Item.java
@@ -1,4 +1,29 @@
 package com.likelion12th.shop.entity;
 
+
+import com.likelion12th.shop.constant.SellStatus;
+import jakarta.persistence.*;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "item")
+@Getter
 public class Item {
+    @Id
+    @Column(name = "item_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String itemName;
+    private Integer price;
+    private Integer stock;
+    private String itemDetail;
+
+    @Enumerated(EnumType.STRING)
+    private SellStatus itemSellStatus;
+    private LocalDateTime createdBy;
+    private LocalDateTime modifiedBy;
+
 }

--- a/src/main/java/com/likelion12th/shop/entity/Item.java
+++ b/src/main/java/com/likelion12th/shop/entity/Item.java
@@ -1,6 +1,7 @@
 package com.likelion12th.shop.entity;
 
 
+import com.likelion12th.shop.Exception.OutOfStockException;
 import com.likelion12th.shop.constant.SellStatus;
 import com.likelion12th.shop.repository.ItemRepository;
 import jakarta.persistence.*;
@@ -33,6 +34,14 @@ public class Item {
     private String itemImg;
     private String itemImgPath;
 
-
-
+    public void removeStock(int stock){
+        int restStock = this.stock - stock;
+        if(restStock<0){
+            throw new OutOfStockException("상품의 재고가 부족 합니다. (현재 재고 수량: " + this.stock + ")");
+        }
+        this.stock = restStock;
+    }
+    public void addStock(int stock){
+        this.stock+=stock;
+    }
 }

--- a/src/main/java/com/likelion12th/shop/entity/Member.java
+++ b/src/main/java/com/likelion12th/shop/entity/Member.java
@@ -1,6 +1,44 @@
 package com.likelion12th.shop.entity;
 
+import com.likelion12th.shop.constant.Role;
+import com.likelion12th.shop.dto.MemberFormDto;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "member")
+@Getter @Setter @ToString
 public class Member {
+    @Id
+    @Column(name = "member_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+    @Column(unique = true)
+    private String email;
+    private String password;
+    private String address;
+
+    @Enumerated(EnumType.STRING)
+    private Role role;
+
+    private LocalDateTime createdBy;
+    private LocalDateTime modifiedBy;
+
+    public static Member createMember(MemberFormDto memberFormDto){
+        Member member=new Member();
+        member.setName(memberFormDto.getName());
+        member.setEmail(member.getEmail());
+        member.setPassword(member.getPassword());
+        member.setAddress(member.getAddress());
+
+        return member;
+    }
 
 
 }

--- a/src/main/java/com/likelion12th/shop/entity/Member.java
+++ b/src/main/java/com/likelion12th/shop/entity/Member.java
@@ -12,7 +12,7 @@ import java.time.LocalDateTime;
 @Entity
 @Table(name = "member")
 @Getter @Setter @ToString
-public class Member {
+public class Member extends BaseTime{
     @Id
     @Column(name = "member_id")
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -26,9 +26,6 @@ public class Member {
 
     @Enumerated(EnumType.STRING)
     private Role role;
-
-    private LocalDateTime createdBy;
-    private LocalDateTime modifiedBy;
 
     public static Member createMember(MemberFormDto memberFormDto){
         Member member=new Member();

--- a/src/main/java/com/likelion12th/shop/entity/Member.java
+++ b/src/main/java/com/likelion12th/shop/entity/Member.java
@@ -6,13 +6,15 @@ import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "member")
 @Getter @Setter @ToString
-public class Member extends BaseTime{
+public class Member extends Base{
     @Id
     @Column(name = "member_id")
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -26,15 +28,28 @@ public class Member extends BaseTime{
 
     @Enumerated(EnumType.STRING)
     private Role role;
-
-    public static Member createMember(MemberFormDto memberFormDto){
+    public static Member createMember(MemberFormDto memberFormDto, PasswordEncoder passwordEncoder){
         Member member=new Member();
         member.setName(memberFormDto.getName());
-        member.setEmail(member.getEmail());
-        member.setPassword(member.getPassword());
-        member.setAddress(member.getAddress());
+        member.setEmail(memberFormDto.getEmail());
+        String pwd=passwordEncoder.encode(memberFormDto.getPassword());
+        member.setPassword(pwd);
+        member.setRole(Role.USER);
+        member.setAddress(memberFormDto.getAddress());
+
 
         return member;
+    }
+    public static Member createAdmin(MemberFormDto memberFormDto, PasswordEncoder passwordEncoder){
+        Member admin=new Member();
+        admin.setName(memberFormDto.getName());
+        admin.setEmail(memberFormDto.getEmail());
+        String pwd=passwordEncoder.encode(memberFormDto.getPassword());
+        admin.setPassword(pwd);
+        admin.setRole(Role.ADMIN);
+        admin.setAddress(memberFormDto.getAddress());
+
+        return admin;
     }
 
 

--- a/src/main/java/com/likelion12th/shop/entity/Order.java
+++ b/src/main/java/com/likelion12th/shop/entity/Order.java
@@ -16,11 +16,12 @@ import java.util.List;
 public class Order {
 
     @Id
-    @Column(name = "oder_id")
+    @Column(name = "order_id")
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     private LocalDateTime OrderDate;
+    @Enumerated(value = EnumType.STRING)
     private OrderStatus OrderStatus;
     private LocalDateTime createdBy;
     private LocalDateTime modifiedBy;
@@ -31,7 +32,6 @@ public class Order {
 
     @OneToMany(mappedBy = "order" ,cascade=CascadeType.ALL, orphanRemoval = true)//연관관계 주인을 mapped by
     private List<OrderItem> orderItemlist=new ArrayList<>();
-
     public Item createItem(){
         Item item=new Item();
         item.setItemName("테스트 상품");
@@ -43,6 +43,36 @@ public class Order {
         item.setModifiedBy(LocalDateTime.now());
 
         return item;
+    }
+    public void addOrderItem(OrderItem orderItem){
+        orderItemlist.add(orderItem);
+        orderItem.setOrder(this);
+    }
+
+    public static Order createOrder(Member member, List<OrderItem> orderItemList) {
+        Order order = new Order();
+        order.setMember(member);
+
+        for(OrderItem orderItem : orderItemList) {
+            order.addOrderItem(orderItem);
+        }
+
+        order.setOrderStatus(com.likelion12th.shop.constant.OrderStatus.ORDER);
+        order.setOrderDate(LocalDateTime.now());
+        return order;
+    }
+    public int getTotalPrice(){
+        int totalPirce=0;
+        for(OrderItem orderItem : orderItemlist){
+            totalPirce+=orderItem.getTotalPrice();
+        }
+        return totalPirce;
+    }
+    public void cancelOrder(){
+        this.OrderStatus=OrderStatus.CANCEL;
+        for(OrderItem orderItem:orderItemlist){
+            orderItem.cancel();
+        }
     }
 
 }

--- a/src/main/java/com/likelion12th/shop/entity/Order.java
+++ b/src/main/java/com/likelion12th/shop/entity/Order.java
@@ -1,4 +1,26 @@
 package com.likelion12th.shop.entity;
 
+import com.likelion12th.shop.constant.OrderStatus;
+import jakarta.persistence.*;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "orders")
+@Getter
 public class Order {
+    @Id
+    @Column(name = "oder_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private LocalDateTime OrderDate;
+    private OrderStatus OrderStatus;
+    private LocalDateTime createdBy;
+    private LocalDateTime modifiedBy;
+
+    @ManyToOne
+    @JoinColumn(name="member_id")//member의 pk랑 조인을 할 예정이고 name옵션은 외래키 컬럼명이다.
+    private Member member;
 }

--- a/src/main/java/com/likelion12th/shop/entity/Order.java
+++ b/src/main/java/com/likelion12th/shop/entity/Order.java
@@ -1,15 +1,20 @@
 package com.likelion12th.shop.entity;
 
 import com.likelion12th.shop.constant.OrderStatus;
+import com.likelion12th.shop.constant.SellStatus;
 import jakarta.persistence.*;
 import lombok.Getter;
+import lombok.Setter;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Table(name = "orders")
-@Getter
+@Getter @Setter
 public class Order {
+
     @Id
     @Column(name = "oder_id")
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -23,4 +28,21 @@ public class Order {
     @ManyToOne
     @JoinColumn(name="member_id")//member의 pk랑 조인을 할 예정이고 name옵션은 외래키 컬럼명이다.
     private Member member;
+
+    @OneToMany(mappedBy = "order" ,cascade=CascadeType.ALL, orphanRemoval = true)//연관관계 주인을 mapped by
+    private List<OrderItem> orderItemlist=new ArrayList<>();
+
+    public Item createItem(){
+        Item item=new Item();
+        item.setItemName("테스트 상품");
+        item.setPrice(10000);
+        item.setItemDetail("테스트 상품 상새 설명");
+        item.setItemSellStatus(SellStatus.SELL);
+        item.setStock(100);
+        item.setCreatedBy(LocalDateTime.now());
+        item.setModifiedBy(LocalDateTime.now());
+
+        return item;
+    }
+
 }

--- a/src/main/java/com/likelion12th/shop/entity/OrderItem.java
+++ b/src/main/java/com/likelion12th/shop/entity/OrderItem.java
@@ -16,11 +16,11 @@ public class OrderItem {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name="item_id")
+    @JoinColumn(name = "item_id")
     private Item item;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name="order_id")
+    @JoinColumn(name = "order_id")
     private Order order;
 
     private Integer oderPrice;
@@ -28,5 +28,18 @@ public class OrderItem {
     private LocalDateTime createdBy;
     private LocalDateTime modifiedBy;
 
-
+    public static OrderItem createOrderItem(Item item, int count) {
+        OrderItem orderItem = new OrderItem();
+        orderItem.setItem(item);
+        orderItem.setCount(count);
+        orderItem.setOderPrice(item.getPrice());
+        item.removeStock(count);
+        return orderItem;
+    }
+    public int getTotalPrice(){
+        return count*oderPrice;
+    }
+    public void cancel(){
+        this.getItem().addStock(count); //count만큼 주문하고 다시 취소
+    }
 }

--- a/src/main/java/com/likelion12th/shop/entity/OrderItem.java
+++ b/src/main/java/com/likelion12th/shop/entity/OrderItem.java
@@ -1,4 +1,30 @@
 package com.likelion12th.shop.entity;
+import jakarta.persistence.*;
+import lombok.Getter;
 
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "order_item")
+@Getter
 public class OrderItem {
+    @Id
+    @Column(name = "orderitem_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name="item_id")
+    private Item item;
+
+    @ManyToOne
+    @JoinColumn(name="order_id")
+    private Order order;
+
+    private Integer oderPrice;
+    private Integer count;
+    private LocalDateTime createdBy;
+    private LocalDateTime modifiedBy;
+
+
 }

--- a/src/main/java/com/likelion12th/shop/entity/OrderItem.java
+++ b/src/main/java/com/likelion12th/shop/entity/OrderItem.java
@@ -1,23 +1,25 @@
 package com.likelion12th.shop.entity;
 import jakarta.persistence.*;
 import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
 
 import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "order_item")
-@Getter
+@Getter @Setter @ToString
 public class OrderItem {
     @Id
     @Column(name = "orderitem_id")
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name="item_id")
     private Item item;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name="order_id")
     private Order order;
 

--- a/src/main/java/com/likelion12th/shop/entity/Review.java
+++ b/src/main/java/com/likelion12th/shop/entity/Review.java
@@ -1,0 +1,37 @@
+package com.likelion12th.shop.entity;
+import com.likelion12th.shop.dto.ReviewFormDto;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "review")
+@Getter @Setter @ToString
+public class Review {
+    @Id
+    @Column(name = "review_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String content;
+    private LocalDateTime createdBy;
+    private LocalDateTime modifiedBy;
+
+    @ManyToOne
+    @JoinColumn(name = "member_id")
+    private Member member;
+    @ManyToOne
+    @JoinColumn(name = "item_id")
+    private Item item;
+
+    public static Review createReview(ReviewFormDto reviewFormDto){
+        Review review=new Review();
+        review.setContent(reviewFormDto.getContent());
+        review.item.getItemName();
+        review.member.getName();
+        return review;
+    }
+}

--- a/src/main/java/com/likelion12th/shop/repository/CartItemRepository.java
+++ b/src/main/java/com/likelion12th/shop/repository/CartItemRepository.java
@@ -1,0 +1,22 @@
+package com.likelion12th.shop.repository;
+
+import com.likelion12th.shop.dto.CartDetailDto;
+import com.likelion12th.shop.entity.Cart;
+import com.likelion12th.shop.entity.CartItem;
+import com.likelion12th.shop.entity.Item;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+
+import java.util.List;
+
+public interface CartItemRepository extends JpaRepository<CartItem, Long> {
+    CartItem findByCartIdAndItemId(Long CartId, Long itemId);
+
+    @Query("SELECT new com.likelion12th.shop.dto.CartDetailDto(ci.id, ci.item.itemName, ci.item.price, ci.count, ci.item.itemImgPath)" +
+        "FROM CartItem ci " + //ci뒤에 띄어쓰기 꼭 하기
+        "WHERE ci.cart.id = :cartId ")
+    List<CartDetailDto>findCartOrderList(@Param("cartId") Long cartId);
+}

--- a/src/main/java/com/likelion12th/shop/repository/CartRepository.java
+++ b/src/main/java/com/likelion12th/shop/repository/CartRepository.java
@@ -1,0 +1,12 @@
+package com.likelion12th.shop.repository;
+
+import com.likelion12th.shop.entity.Cart;
+import com.likelion12th.shop.entity.Member;
+import com.likelion12th.shop.entity.Order;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface CartRepository extends JpaRepository<Cart,Long> {
+    Cart findByMember(Member member);
+}

--- a/src/main/java/com/likelion12th/shop/repository/ItemRepository.java
+++ b/src/main/java/com/likelion12th/shop/repository/ItemRepository.java
@@ -1,0 +1,7 @@
+package com.likelion12th.shop.repository;
+
+import com.likelion12th.shop.entity.Item;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ItemRepository extends JpaRepository<Item,Long>{
+}

--- a/src/main/java/com/likelion12th/shop/repository/ItemRepository.java
+++ b/src/main/java/com/likelion12th/shop/repository/ItemRepository.java
@@ -16,5 +16,7 @@ public interface ItemRepository extends JpaRepository<Item,Long>{
             "%:itemDetail% order by i.price desc ") //i가 생각되면 안됨.
     List<Item> findByItemDetail(@Param("itemDetail") String itemDetail);
 
+    List<Item>findByItemNameContainingIgnoreCase(String itemName);
+
 
 }

--- a/src/main/java/com/likelion12th/shop/repository/ItemRepository.java
+++ b/src/main/java/com/likelion12th/shop/repository/ItemRepository.java
@@ -1,7 +1,20 @@
 package com.likelion12th.shop.repository;
 
+import com.likelion12th.shop.constant.SellStatus;
 import com.likelion12th.shop.entity.Item;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
+import java.util.List;
 
 public interface ItemRepository extends JpaRepository<Item,Long>{
+    List<Item> findByItemName(String itemName);
+    List<Item> findByPriceLessThanOrderByPriceDesc(Integer price);
+    @Query("select i from Item i  where i.itemDetail like " +
+            "%:itemDetail% order by i.price desc ") //i가 생각되면 안됨.
+    List<Item> findByItemDetail(@Param("itemDetail") String itemDetail);
+
+
 }

--- a/src/main/java/com/likelion12th/shop/repository/MemberRepository.java
+++ b/src/main/java/com/likelion12th/shop/repository/MemberRepository.java
@@ -1,0 +1,7 @@
+package com.likelion12th.shop.repository;
+
+import com.likelion12th.shop.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member,Long> {//엔티티, pk 자료형
+}

--- a/src/main/java/com/likelion12th/shop/repository/MemberRepository.java
+++ b/src/main/java/com/likelion12th/shop/repository/MemberRepository.java
@@ -4,4 +4,5 @@ import com.likelion12th.shop.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberRepository extends JpaRepository<Member,Long> {//엔티티, pk 자료형
+    Member findByEmail(String email);
 }

--- a/src/main/java/com/likelion12th/shop/repository/OrderItemRepository.java
+++ b/src/main/java/com/likelion12th/shop/repository/OrderItemRepository.java
@@ -1,0 +1,7 @@
+package com.likelion12th.shop.repository;
+
+import com.likelion12th.shop.entity.OrderItem;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OrderItemRepository extends JpaRepository<OrderItem,Long> {
+}

--- a/src/main/java/com/likelion12th/shop/repository/OrderRepository.java
+++ b/src/main/java/com/likelion12th/shop/repository/OrderRepository.java
@@ -1,5 +1,10 @@
 package com.likelion12th.shop.repository;
 import com.likelion12th.shop.entity.Order;
 import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
 public interface OrderRepository extends JpaRepository<Order,Long>{
+    List<Order> findByMemberEmail(String email);
 }
+

--- a/src/main/java/com/likelion12th/shop/repository/OrderRepository.java
+++ b/src/main/java/com/likelion12th/shop/repository/OrderRepository.java
@@ -1,0 +1,5 @@
+package com.likelion12th.shop.repository;
+import com.likelion12th.shop.entity.Order;
+import org.springframework.data.jpa.repository.JpaRepository;
+public interface OrderRepository extends JpaRepository<Order,Long>{
+}

--- a/src/main/java/com/likelion12th/shop/repository/ReviewRepository.java
+++ b/src/main/java/com/likelion12th/shop/repository/ReviewRepository.java
@@ -1,0 +1,7 @@
+package com.likelion12th.shop.repository;
+
+import com.likelion12th.shop.entity.Review;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReviewRepository extends JpaRepository<Review,Long> {
+}

--- a/src/main/resources/templates/main.html
+++ b/src/main/resources/templates/main.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org/"
+      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      xmlns:sec="http://www.thymeleaf.org/extras/spring-security"
+      layout:decorate="~{layouts/layout1}">
+
+<div layout:fragment="content">
+    <h1>메인페이지입니다.</h1>
+</div>
+
+<div>
+    <button type="button" class="btn btn-primary" sec:authorize="isAnonymous()" onClick="location.href='/members/login'">로그인</button>
+</div>
+
+<div>
+    <button type="button" class="btn btn-primary" sec:authorize="isAuthenticated()" onClick="location.href='/members/logout'">로그아웃</button>
+</div>
+<div>
+    <button type="button" class="btn btn-primary" sec:authorize="isAnonymous()" onClick="location.href='/members/adminnew'">관리자가입</button>
+</div>
+<div>
+    <button type="button" class="btn btn-primary" sec:authorize="hasRole('ADMIN')" onClick="location.href='/admin/page'">관리자페이지</button>
+</div>
+
+</html>

--- a/src/main/resources/templates/member/admin.html
+++ b/src/main/resources/templates/member/admin.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org"
+      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      xmlns:sec="http://www.thymeleaf.org/extras/spring-security"
+      layout:decorate="~{layouts/layout1}">
+<head>
+    <meta charset="UTF-8">
+</head>
+<body>
+
+<!-- 관리자 페이지 버튼 -->
+<sec:authorize access="hasRole('ADMIN')">
+    <p>관리자만 이 페이지를 볼 수 있습니다!</p>
+</sec:authorize>
+
+</body>
+</html>

--- a/src/main/resources/templates/member/memberForm.html
+++ b/src/main/resources/templates/member/memberForm.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org"
+      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      layout:decorate="~{layouts/layout1}">
+<!--<head>-->
+    <!--  csrf token  -->
+<!--    <meta name="_csrf" th:content="${_csrf.token}">-->
+<!--    <meta name="_csrf_parameter" th:content="${_csrf.parameterName}"/>-->
+<!--</head>-->
+<!-- 사용자 CSS 추가 -->
+<th:block layout:fragment="css">
+    <style>
+        .fieldError {
+            color: #bd2130;
+        }
+        .hidden {
+            display: none;
+        }
+    </style>
+</th:block>
+
+<!-- 사용자 스크립트 추가 -->
+<th:block layout:fragment="script">
+
+    <script th:inline="javascript">
+        $(document).ready(function(){
+            var errorMessage = [[${errorMessage}]];
+            if(errorMessage != null){
+                alert(errorMessage);
+            }
+        });
+    </script>
+
+</th:block>
+
+<div layout:fragment="content">
+
+    <form action="/members/new" role="form" method="post"  th:object="${memberFormDto}">
+        <div class="form-group">
+            <label th:for="name">이름</label>
+            <input type="text" th:field="*{name}" class="form-control" placeholder="이름을 입력해주세요">
+            <p th:if="${#fields.hasErrors('name')}" th:errors="*{name}" class="fieldError">Incorrect data</p>
+        </div>
+        <div class="form-group">
+            <label th:for="email">이메일주소</label>
+            <input type="email" th:field="*{email}" class="form-control" placeholder="이메일을 입력해주세요">
+            <p th:if="${#fields.hasErrors('email')}" th:errors="*{email}" class="fieldError">Incorrect data</p>
+        </div>
+        <div class="form-group">
+            <label th:for="password">비밀번호</label>
+            <input type="password" th:field="*{password}" class="form-control" placeholder="비밀번호 입력">
+            <p th:if="${#fields.hasErrors('password')}" th:errors="*{password}" class="fieldError">Incorrect data</p>
+        </div>
+        <div class="form-group">
+            <label th:for="address">주소</label>
+            <input type="text" th:field="*{address}" class="form-control" placeholder="주소를 입력해주세요">
+            <p th:if="${#fields.hasErrors('address')}" th:errors="*{address}" class="fieldError">Incorrect data</p>
+        </div>
+
+        <div style="text-align: center">
+            <button type="submit" class="btn btn-primary" style="">Submit</button>
+        </div>
+        <input type="hidden" th:name="_csrf_parameter" th:value="_csrf">
+    </form>
+
+</div>
+
+</html>

--- a/src/main/resources/templates/member/memberLoginForm.html
+++ b/src/main/resources/templates/member/memberLoginForm.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org/"
+      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      layout:decorate="~{layouts/layout1}">
+
+
+<!-- 사용자 CSS 추가 -->
+<th:block layout:fragment="css">
+    <style>
+        .error {
+            color: #bd2130;
+        }
+    </style>
+</th:block>
+
+<div layout:fragment="content">
+
+    <form role="form" method="post" action="/members/login">
+        <div class="form-group">
+            <label th:for="email">이메일주소</label>
+            <input type="email" name="email" class="form-control" placeholder="이메일을 입력해주세요">
+        </div>
+        <div class="form-group">
+            <label th:for="password">비밀번호</label>
+            <input type="password" name="password" id="password" class="form-control" placeholder="비밀번호 입력">
+        </div>
+        <p th:if="${loginErrorMsg}" class="error" th:text="${loginErrorMsg}"></p>
+        <button class="btn btn-primary">로그인</button>
+        <button type="button" class="btn btn-primary" onClick="location.href='/members/new'">회원가입</button>
+        <input type="hidden" th:name="_csrf_parameter" th:value="_csrf">
+    </form>
+
+</div>
+
+</html>

--- a/src/test/java/com/likelion12th/shop/Service/MemberServiceTest.java
+++ b/src/test/java/com/likelion12th/shop/Service/MemberServiceTest.java
@@ -1,0 +1,61 @@
+package com.likelion12th.shop.Service;
+
+import com.likelion12th.shop.dto.MemberFormDto;
+import com.likelion12th.shop.entity.Member;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.TestPropertySource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@SpringBootTest
+@Transactional
+@TestPropertySource(locations="classpath:application.properties")
+public class MemberServiceTest {
+    @Autowired
+    MemberService memberService;
+
+    @Autowired
+    PasswordEncoder passwordEncoder;
+
+    public Member createMember(){
+        MemberFormDto memberFormDto=new MemberFormDto();
+        memberFormDto.setName("user1");
+        memberFormDto.setEmail("123@naver.com");
+        memberFormDto.setAddress("노원구");
+        memberFormDto.setPassword("asdf1234");
+        Member member=Member.createAdmin(memberFormDto,passwordEncoder);
+        return member;
+    }
+    @Test
+    @DisplayName("회원가입 테스트")
+    public void saveMember(){
+        Member member=createMember();
+        Member savemember=memberService.saveMember(member);
+        assertEquals(member.getEmail(),savemember.getEmail());
+        assertEquals(member.getName(),savemember.getName());
+        assertEquals(member.getAddress(),savemember.getAddress());
+        assertEquals(member.getPassword(),savemember.getPassword());
+        //생성한 객체와 저장한 객체의 필드끼리 비교
+        System.out.println(savemember.getRole().toString());
+     }
+
+    @Test
+    @DisplayName("중복 회원가입 테스트")
+    public void setDuplicateMemberTest(){
+        Member member1=createMember();
+        Member member2=createMember();
+        memberService.saveMember(member1);
+
+        Throwable e=assertThrows(IllegalStateException.class, () -> {
+            memberService.saveMember(member2);
+        });
+        assertEquals("이미 가입된 회원입니다. ",e.getMessage());
+        }
+    }
+

--- a/src/test/java/com/likelion12th/shop/entity/MemberTest.java
+++ b/src/test/java/com/likelion12th/shop/entity/MemberTest.java
@@ -1,0 +1,41 @@
+package com.likelion12th.shop.entity;
+
+import com.likelion12th.shop.repository.MemberRepository;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityNotFoundException;
+import jakarta.persistence.PersistenceContext;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.security.test.context.support.WithMockUser;
+@SpringBootTest
+@TestPropertySource(locations = "classpath:application.properties")
+@Transactional
+public class MemberTest {
+    @Autowired
+    MemberRepository memberRepository;
+    @PersistenceContext
+    EntityManager em;
+
+    @Test
+    @DisplayName("Auditing 테스트")
+    @WithMockUser(username = "mk", roles = "USER")
+    public void auditingTest(){
+        Member member1=new Member();
+        member1=memberRepository.save(member1);
+
+        em.flush();
+        em.clear();
+
+        Member member=memberRepository.findById(member1.getId())
+                .orElseThrow(EntityNotFoundException::new);
+
+        System.out.println("register time : " + member.getRegTime());
+        System.out.println("update time : " + member.getUpdateTime());
+        System.out.println("creater : " + member.getCreatedBy());
+        System.out.println("modifier : " + member.getModifiedBy());
+    }
+}

--- a/src/test/java/com/likelion12th/shop/entity/OrderTest.java
+++ b/src/test/java/com/likelion12th/shop/entity/OrderTest.java
@@ -1,0 +1,121 @@
+package com.likelion12th.shop.entity;
+
+import com.likelion12th.shop.constant.SellStatus;
+import com.likelion12th.shop.repository.ItemRepository;
+import com.likelion12th.shop.repository.MemberRepository;
+import com.likelion12th.shop.repository.OrderItemRepository;
+import com.likelion12th.shop.repository.OrderRepository;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityNotFoundException;
+import jakarta.persistence.PersistenceContext;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.*;
+@SpringBootTest
+@Transactional
+@TestPropertySource(locations = "classpath:application.properties")
+class OrderTest {
+    @PersistenceContext
+    EntityManager em;
+
+    @Autowired
+    private ItemRepository itemRepository;
+    @Autowired
+    private OrderRepository orderRepository;
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private OrderItemRepository orderItemRepository;
+    public Item createItem() {
+        Item item = new Item();
+        item.setItemName("테스트 상품");
+        item.setPrice(10000);
+        item.setItemDetail("테스트 상품 상새 설명");
+        item.setItemSellStatus(SellStatus.SELL);
+        item.setStock(100);
+        item.setCreatedBy(LocalDateTime.now());
+        item.setModifiedBy(LocalDateTime.now());
+
+        return item;
+    }
+    public Order createOrder(){
+        Order order=new Order();
+        for(int i=0;i<3;i++){
+            //item 생성
+            Item item = this.createItem();
+            itemRepository.save(item);
+            //orderitem 생성
+            OrderItem orderItem = new OrderItem();
+            orderItem.setCount(10);
+            orderItem.setOderPrice(1000);
+            orderItem.setOrder(order);
+            order.getOrderItemlist().add(orderItem);
+        }
+        //회원 생성
+        Member member = new Member();
+        memberRepository.save(member);
+        //주문 생성
+        order.setMember(member);
+        orderRepository.save(order);
+
+        return order;
+    }
+
+
+    @Test
+    @DisplayName("영속성 전이 테스트")
+    public void cascadeTest() {
+        Order order = new Order();
+
+        for (int i = 0; i < 3; i++) {
+            Item item = this.createItem();
+            itemRepository.save(item);
+
+            OrderItem orderItem = new OrderItem();
+            orderItem.setCount(10);
+            orderItem.setOderPrice(1000);
+            orderItem.setOrder(order);
+            order.getOrderItemlist().add(orderItem);
+        }
+        orderRepository.saveAndFlush(order);
+        em.clear();
+        Order saveOrder=orderRepository.findById(order.getId())
+                .orElseThrow(EntityNotFoundException::new);
+        assertEquals(3,order.getOrderItemlist().size());
+    }
+
+    @Test
+    @DisplayName("고아객체 제거 테스트")
+    public void orphanRemovalTest(){
+        Order order = this.createOrder();
+        order.getOrderItemlist().remove(0);
+        em.flush();
+    }
+
+    @Test
+    @DisplayName("지연 로딩 테스트")
+    public void lazyLoadingTest(){
+        Order order=this.createOrder();
+        //생성한 주문의 첫 번째 주문 상품 id 조회
+        Long orderItemId=order.getOrderItemlist().get(0).getId();
+        em.flush();
+        em.clear();
+
+        //id로 주문 상품 조회
+        OrderItem orderItem=orderItemRepository.findById(orderItemId)
+                .orElseThrow(EntityNotFoundException::new);
+        System.out.println("Order class : " + orderItem.getOrder().getClass());
+        System.out.println("================");
+        orderItem.getOrder().getOrderDate();
+        System.out.println("================");
+
+    }
+}

--- a/src/test/java/com/likelion12th/shop/repository/ItemRepositoryTest.java
+++ b/src/test/java/com/likelion12th/shop/repository/ItemRepositoryTest.java
@@ -69,6 +69,7 @@ public class ItemRepositoryTest {
 }
     @Test
     @DisplayName("가격 내림차순 조회 테스트")
+
     public void findByPriceLessThanOrderByPriceDescTest(){
         this.createItemList();
         List<Item> pricelist=itemRepository.findByPriceLessThanOrderByPriceDesc(10005);
@@ -95,7 +96,7 @@ public class ItemRepositoryTest {
 
         JPAQuery<Item> query=queryFactory.selectFrom(qItem)
                 .where(qItem.itemSellStatus.eq(SellStatus.SELL))
-                .where(qItem.itemDetail.like("%"+"상세 설명"+"%"))
+                .where(qItem.itemDetail.like("%"+"상세 설명 5"+"%"))
                 .orderBy(qItem.price.desc());
         List<Item>itemList=query.fetch();
         for(Item item:itemList){

--- a/src/test/java/com/likelion12th/shop/repository/ItemRepositoryTest.java
+++ b/src/test/java/com/likelion12th/shop/repository/ItemRepositoryTest.java
@@ -1,0 +1,108 @@
+package com.likelion12th.shop.repository;
+
+import com.likelion12th.shop.constant.SellStatus;
+import com.likelion12th.shop.entity.Item;
+import com.likelion12th.shop.entity.Member;
+import com.likelion12th.shop.entity.QItem;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionMessage;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@SpringBootTest
+@Transactional
+@TestPropertySource(locations = "classpath:application.properties")
+public class ItemRepositoryTest {
+    @PersistenceContext
+    EntityManager em;
+
+    @Autowired
+    private ItemRepository itemRepository;
+
+    @Test
+    @DisplayName("상품 저장 테스트")
+    public void createItemTest() {
+        Item item = new Item();
+        item.setItemName("테스트 상품");
+        item.setPrice(10000);
+        item.setItemDetail("테스트 상품 상새 설명");
+        item.setItemSellStatus(SellStatus.SELL);
+        item.setStock(100);
+        item.setCreatedBy(LocalDateTime.now());
+        item.setModifiedBy(LocalDateTime.now());
+
+        Item saveItem = itemRepository.save(item);
+        System.out.println(saveItem.toString());
+    }
+
+    public void createItemList() {
+        for (int i = 0; i < 10; i++) {
+            Item item = new Item();
+            item.setItemName("테스트 상품 " + i);
+            item.setPrice(10000+i);
+            item.setItemDetail("테스트 상품 상세 설명 " + i);
+            item.setItemSellStatus(SellStatus.SELL);
+            item.setStock(100);
+            item.setCreatedBy(LocalDateTime.now());
+            item.setModifiedBy(LocalDateTime.now());
+
+            Item saveItem = itemRepository.save(item);
+        }
+
+    }
+    @Test
+    @DisplayName("상품명 조회 테스트")
+    public void findByItemNameList(){
+        this.createItemList();
+        List<Item> itemList=itemRepository.findByItemName("테스트 상품 5");
+        for(Item item:itemList)System.out.println(item.toString());
+}
+    @Test
+    @DisplayName("가격 내림차순 조회 테스트")
+    public void findByPriceLessThanOrderByPriceDescTest(){
+        this.createItemList();
+        List<Item> pricelist=itemRepository.findByPriceLessThanOrderByPriceDesc(10005);
+        for(Item item:pricelist){
+            System.out.println(item.toString());
+        }
+    }
+
+    @Test
+    @DisplayName("@Query를 이용한  상품 조회 테스트")
+    public void findByItemDetailTest(){
+        this.createItemList();
+        List<Item> detaillist=itemRepository.findByItemDetail("테스트 상품 상세 설명");
+        for(Item item:detaillist)System.out.println(item.toString());
+    }
+
+    @Test
+    @DisplayName("Querydsl 조회 테스트")
+    public void queryDsltest(){
+        this.createItemList();
+        JPAQueryFactory queryFactory=new JPAQueryFactory(em);
+        //jpaqeryfactory를 통해 쿼리를 동적으로 생성
+        QItem qItem=QItem.item;
+
+        JPAQuery<Item> query=queryFactory.selectFrom(qItem)
+                .where(qItem.itemSellStatus.eq(SellStatus.SELL))
+                .where(qItem.itemDetail.like("%"+"상세 설명"+"%"))
+                .orderBy(qItem.price.desc());
+        List<Item>itemList=query.fetch();
+        for(Item item:itemList){
+            System.out.println(item.toString());
+        }
+
+        
+    }
+    }
+

--- a/src/test/java/com/likelion12th/shop/repository/MemberRepositoryTest.java
+++ b/src/test/java/com/likelion12th/shop/repository/MemberRepositoryTest.java
@@ -19,7 +19,7 @@ class MemberRepositoryTest {
     MemberRepository memberRepository;
 
     @Test
-    @DisplayName("상품 테스트")
+    @DisplayName("회원 테스트")
     public void CreateMemberTest(){
         Member member=new Member();
         member.setName("이민경");

--- a/src/test/java/com/likelion12th/shop/repository/MemberRepositoryTest.java
+++ b/src/test/java/com/likelion12th/shop/repository/MemberRepositoryTest.java
@@ -1,0 +1,35 @@
+package com.likelion12th.shop.repository;
+
+import com.likelion12th.shop.entity.Member;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@Transactional
+@TestPropertySource(locations = "classpath:application.properties")
+class MemberRepositoryTest {
+
+    @Autowired
+    MemberRepository memberRepository;
+
+    @Test
+    @DisplayName("상품 테스트")
+    public void CreateMemberTest(){
+        Member member=new Member();
+        member.setName("이민경");
+        member.setEmail("test@naver.com");
+        member.setPassword("test");
+        member.setAddress("서울시");
+
+
+        Member savedMember=memberRepository.save(member);
+        System.out.println(savedMember.toString());
+
+    }
+}

--- a/src/test/java/com/likelion12th/shop/repository/ReviewRepositoryTest.java
+++ b/src/test/java/com/likelion12th/shop/repository/ReviewRepositoryTest.java
@@ -1,0 +1,35 @@
+package com.likelion12th.shop.repository;
+import com.likelion12th.shop.entity.Item;
+import com.likelion12th.shop.entity.Review;
+import com.likelion12th.shop.entity.Member;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+
+@SpringBootTest
+@Transactional
+@TestPropertySource(locations = "classpath:application.properties")
+public class ReviewRepositoryTest {
+
+    @Autowired
+    ReviewRepository reviewRepository;
+
+    @Test
+    @DisplayName("댓글 테스트")
+    public void CreateReviewTest(){
+        Member member=new Member();
+        Item item = new Item();
+        Review review = new Review();
+        review.setContent("Test Review Content");
+        review.setMember(member);
+        review.setItem(item);
+
+
+
+        Review savedReivew=reviewRepository.save(review);
+        System.out.println(savedReivew.toString());
+    }
+}


### PR DESCRIPTION
메인 페이지에서 관리자가입 버튼을 누르면 관리자로 가입할 수 있는 주소로 넘어간다. 

- Member 엔티티에 createAdmin을 생성해 멤버 테이블에서 Role을 ADMIN으로 SET할 수 있도록 했다.
- 컨트롤러에서 createAdmin()을 호출해 어드민 객체를 만들면 멤버서비스 saveMember로 넘긴다. 
- 인터페이스 AccessDeniedHandle를 CustomAccessDeniedHandle로 구현하고 securityConfig에서 .requestMatchers("/admin/**").hasRole("ADMIN")로 지정해 admin이하의 주소는 관리자 권한을 가진 사람만 볼 수 있도록 했다.
- main.html에서  sec:authorize="hasRole('ADMIN')" onClick="location.href='/admin/page'"로 지정해 관리자 계정으로 로그인했을 때만 관리자 페이지로 넘어갈 수 있게 했다. 
- 
