### PR TITLE
[10주차] 엄서희_BE 과제 제출 최종

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,7 @@ dependencies {
 	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
 	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 	implementation('commons-io:commons-io:2.11.0')
+	implementation 'org.modelmapper:modelmapper:2.3.9'
 }
 
 tasks.named('bootBuildImage') {

--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,12 @@ dependencies {
 	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 	implementation('commons-io:commons-io:2.11.0')
 	implementation 'org.modelmapper:modelmapper:2.3.9'
+	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'
+	testImplementation 'org.springframework.security:spring-security-test'
+	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 }
 
 tasks.named('bootBuildImage') {

--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,7 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	testImplementation 'org.projectlombok:lombok:1.18.28'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
@@ -32,6 +33,7 @@ dependencies {
 	annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
 	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
 	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+	implementation('commons-io:commons-io:2.11.0')
 }
 
 tasks.named('bootBuildImage') {

--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,10 @@ dependencies {
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+	annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 }
 
 tasks.named('bootBuildImage') {
@@ -36,4 +40,13 @@ tasks.named('bootBuildImage') {
 
 tasks.named('test') {
 	useJUnitPlatform()
+}
+
+def querydslDir = "$buildDir/generated/querydsl"
+
+sourceSets {
+	main.java.srcDir querydslDir
+}
+configurations {
+	querydsl.extendsFrom compileClasspath
 }

--- a/src/main/java/com/likelion12th/shop/ShopApplication.java
+++ b/src/main/java/com/likelion12th/shop/ShopApplication.java
@@ -1,8 +1,10 @@
 package com.likelion12th.shop;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class ShopApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/likelion12th/shop/config/AuditConfig.java
+++ b/src/main/java/com/likelion12th/shop/config/AuditConfig.java
@@ -1,2 +1,13 @@
-package com.likelion12th.shop.config;public class AuditConfig {
+package com.likelion12th.shop.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.domain.AuditorAware;
+
+@Configuration
+public class AuditConfig {
+    @Bean
+    public AuditorAware<String> auditorProvider() {
+        return new AuditorAwareImpl();
+    }
 }

--- a/src/main/java/com/likelion12th/shop/config/AuditConfig.java
+++ b/src/main/java/com/likelion12th/shop/config/AuditConfig.java
@@ -1,0 +1,2 @@
+package com.likelion12th.shop.config;public class AuditConfig {
+}

--- a/src/main/java/com/likelion12th/shop/config/AuditorAwareImpl.java
+++ b/src/main/java/com/likelion12th/shop/config/AuditorAwareImpl.java
@@ -1,0 +1,2 @@
+package com.likelion12th.shop.config;public class AuditorAwareImpl {
+}

--- a/src/main/java/com/likelion12th/shop/config/AuditorAwareImpl.java
+++ b/src/main/java/com/likelion12th/shop/config/AuditorAwareImpl.java
@@ -1,2 +1,20 @@
-package com.likelion12th.shop.config;public class AuditorAwareImpl {
+package com.likelion12th.shop.config;
+
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.util.Optional;
+
+public class AuditorAwareImpl implements AuditorAware<String> {
+    @Override
+    public Optional<String> getCurrentAuditor() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        String userId = "";
+        if (authentication != null) {
+            userId = authentication.getName();
+        }
+        return Optional.of(userId);
+    }
 }

--- a/src/main/java/com/likelion12th/shop/config/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/likelion12th/shop/config/CustomAccessDeniedHandler.java
@@ -1,2 +1,22 @@
-package com.likelion12th.shop.config;public class CustomAccessDeniedHandler {
+package com.likelion12th.shop.config;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.ToString;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+@ToString
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException, ServletException {
+        response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+        response.setContentType("text/plain;charset=UTF-8");
+        response.getWriter().write("접근 거부: 권한이 없습니다.");
+    }
 }

--- a/src/main/java/com/likelion12th/shop/config/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/likelion12th/shop/config/CustomAccessDeniedHandler.java
@@ -1,0 +1,2 @@
+package com.likelion12th.shop.config;public class CustomAccessDeniedHandler {
+}

--- a/src/main/java/com/likelion12th/shop/config/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/likelion12th/shop/config/CustomAuthenticationEntryPoint.java
@@ -1,2 +1,20 @@
-package com.likelion12th.shop.config;public class CustomAuthenticationEntryPoint {
+package com.likelion12th.shop.config;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.web.AuthenticationEntryPoint;
+
+import javax.naming.AuthenticationException;
+import java.io.IOException;
+
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, org.springframework.security.core.AuthenticationException authException) throws IOException, ServletException {
+        if ("XMLHttpRequest".equals(request.getHeader("x-requested-with"))) {
+            response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Unauthorized");
+        } else {
+            response.sendRedirect("/members/login");
+        }
+    }
 }

--- a/src/main/java/com/likelion12th/shop/config/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/likelion12th/shop/config/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,2 @@
+package com.likelion12th.shop.config;public class CustomAuthenticationEntryPoint {
+}

--- a/src/main/java/com/likelion12th/shop/config/SecurityConfig.java
+++ b/src/main/java/com/likelion12th/shop/config/SecurityConfig.java
@@ -1,2 +1,60 @@
-package com.likelion12th.shop.config;public class SecurityConfig {
+package com.likelion12th.shop.config;
+
+import com.likelion12th.shop.config.CustomAuthenticationEntryPoint;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .formLogin(form -> form
+                        .loginPage("/members/login")
+                        .defaultSuccessUrl("/")
+                        .usernameParameter("email")
+                        .passwordParameter("password")
+                        .failureUrl("/members/login/error")
+                        .permitAll()
+                )
+                .logout(logout -> logout
+                        .logoutRequestMatcher(new AntPathRequestMatcher("/members/logout"))
+                        .logoutSuccessUrl("/")
+                        .invalidateHttpSession(true)
+                        .deleteCookies("JSESSIONID")
+                        .permitAll()
+                );
+
+        // 보안검사
+        http
+                .authorizeHttpRequests(requests -> requests
+                        .requestMatchers("/members/login").anonymous()
+                        .requestMatchers("/members/logout").authenticated()
+                        .requestMatchers("/adminPage").hasRole("ADMIN")
+                        .anyRequest().permitAll()
+                );
+
+        // 인증 실패시 대처 방법 커스텀
+        http
+                .exceptionHandling(error -> error
+                        .authenticationEntryPoint(new CustomAuthenticationEntryPoint())
+                        .accessDeniedHandler(new CustomAccessDeniedHandler())
+                );
+
+        return http.build();
+    }
 }

--- a/src/main/java/com/likelion12th/shop/config/SecurityConfig.java
+++ b/src/main/java/com/likelion12th/shop/config/SecurityConfig.java
@@ -1,0 +1,2 @@
+package com.likelion12th.shop.config;public class SecurityConfig {
+}

--- a/src/main/java/com/likelion12th/shop/constant/ItemSellStatus.java
+++ b/src/main/java/com/likelion12th/shop/constant/ItemSellStatus.java
@@ -1,0 +1,5 @@
+package com.likelion12th.shop.constant;
+
+public enum ItemSellStatus {
+    SELL, SOLD
+}

--- a/src/main/java/com/likelion12th/shop/constant/OrderStatus.java
+++ b/src/main/java/com/likelion12th/shop/constant/OrderStatus.java
@@ -1,0 +1,5 @@
+package com.likelion12th.shop.constant;
+
+public enum OrderStatus {
+    CANCEL, ORDER
+}

--- a/src/main/java/com/likelion12th/shop/constant/Role.java
+++ b/src/main/java/com/likelion12th/shop/constant/Role.java
@@ -1,0 +1,5 @@
+package com.likelion12th.shop.constant;
+
+public enum Role {
+    USER, ADMIN
+}

--- a/src/main/java/com/likelion12th/shop/constant/itemSellStatus.java
+++ b/src/main/java/com/likelion12th/shop/constant/itemSellStatus.java
@@ -1,5 +1,0 @@
-package com.likelion12th.shop.constant;
-
-public enum itemSellStatus {
-    InStock, OutOfStock
-}

--- a/src/main/java/com/likelion12th/shop/constant/itemSellStatus.java
+++ b/src/main/java/com/likelion12th/shop/constant/itemSellStatus.java
@@ -1,0 +1,5 @@
+package com.likelion12th.shop.constant;
+
+public enum itemSellStatus {
+    InStock, OutOfStock
+}

--- a/src/main/java/com/likelion12th/shop/controller/AdminController.java
+++ b/src/main/java/com/likelion12th/shop/controller/AdminController.java
@@ -1,0 +1,2 @@
+package com.likelion12th.shop.controller;public class AdminController {
+}

--- a/src/main/java/com/likelion12th/shop/controller/AdminController.java
+++ b/src/main/java/com/likelion12th/shop/controller/AdminController.java
@@ -1,2 +1,17 @@
-package com.likelion12th.shop.controller;public class AdminController {
+package com.likelion12th.shop.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+@RequiredArgsConstructor
+public class AdminController {
+
+    @GetMapping("/adminpage")
+    public String adminPage() {
+        return "member/adminPage";
+    }
+
 }
+

--- a/src/main/java/com/likelion12th/shop/controller/CartController.java
+++ b/src/main/java/com/likelion12th/shop/controller/CartController.java
@@ -1,0 +1,69 @@
+package com.likelion12th.shop.controller;
+
+import com.likelion12th.shop.dto.CartDetailDto;
+import com.likelion12th.shop.dto.CartItemDto;
+import com.likelion12th.shop.dto.CartOrderDto;
+import com.likelion12th.shop.entity.CartItem;
+import com.likelion12th.shop.service.CartService;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/cart")
+public class CartController {
+    private final CartService cartService;
+
+    @PostMapping("/add")
+    public ResponseEntity<String> addCartItems(@RequestParam String email, @RequestBody List<CartItemDto> cartItemDtos) {
+        cartService.addCartItems(email, cartItemDtos);
+        return ResponseEntity.ok("장바구니에 상품을 담았음");
+    }
+
+    @GetMapping
+    public ResponseEntity<List<CartDetailDto>> getCart(@RequestParam String email) {
+        List<CartDetailDto> cartDetailDto = cartService.getCartList(email);
+        return ResponseEntity.ok(cartDetailDto);
+    }
+
+    @DeleteMapping("/{cartItemId}")
+    public ResponseEntity<String> deleteCartItem(@RequestParam String email, @PathVariable Long cartItemId){
+        try{
+            cartService.deleteCartItem(email, cartItemId);
+            return ResponseEntity.ok("장바구니에서 상품 삭제됨 : " + cartItemId);
+        } catch (EntityNotFoundException e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body("해당 상품 ID 없음 : " + cartItemId);
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).body("해당 사용자의 장바구니에 없는 상품임");
+        }
+    }
+
+    @PatchMapping("")
+    public ResponseEntity<String> updateCartItemCount(@RequestParam String email, @RequestBody CartDetailDto cartDetailDto) {
+        try {
+            cartService.updateCartItemCount(email, cartDetailDto);
+            return ResponseEntity.ok("상품 ID : " + cartDetailDto.getCartItemId() + ", 수량 : " + cartDetailDto.getCount());
+        } catch (EntityNotFoundException e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body("해당 상품 ID가 없음");
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).body("해당 사용자의 장바구니에 없는 상품임");
+        }
+    }
+
+    @PostMapping("/orders")
+    public ResponseEntity<String> orderCartItem(@RequestParam String email, @RequestBody CartOrderDto cartOrderDto) {
+        List<CartOrderDto> cartOrderDtoList = cartOrderDto.getCartOrderDtoList();
+        try {
+            Long orderId = cartService.orderCartItem(email, cartOrderDtoList);
+
+            return ResponseEntity.ok("사용자 : " + email + ", 주문 : " + orderId);
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("주문 실패 : " + e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/likelion12th/shop/controller/ItemController.java
+++ b/src/main/java/com/likelion12th/shop/controller/ItemController.java
@@ -65,4 +65,40 @@ public class ItemController {
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
         }
     }
+
+    @GetMapping("/search")
+    public ResponseEntity<List<ItemFormDto>> searchItemsByName(@RequestParam("itemName") String itemName) {
+        try {
+            List<ItemFormDto> itemFormDtos = itemService.getItemsByName(itemName);
+            return ResponseEntity.ok().body(itemFormDtos);
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
+    }
+
+    @PatchMapping("/{itemId}")
+    public ResponseEntity<String> updateItem(@PathVariable Long itemId,
+                                           @RequestPart(name = "itemFormDto") ItemFormDto itemFormDto,
+                                           @RequestPart(value = "itemImg", required = false) MultipartFile itemImg) {
+        try {
+            itemService.updateItem(itemId, itemFormDto, itemImg);
+            return ResponseEntity.ok().body("상품이 성공적으로 수정되었습니다.");
+        } catch (HttpClientErrorException e) {
+            return ResponseEntity.status(e.getStatusCode()).body("상품을 찾을 수 없습니다.");
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
+    }
+
+    @DeleteMapping("/{itemId}")
+    public ResponseEntity<String> deleteItem(@PathVariable Long itemId) {
+        try {
+            itemService.deleteItem(itemId);
+            return ResponseEntity.ok().body("상품이 성공적으로 삭제되었습니다.");
+        } catch (HttpClientErrorException e) {
+            return ResponseEntity.status(e.getStatusCode()).body("상품을 찾을 수 없습니다.");
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
+    }
 }

--- a/src/main/java/com/likelion12th/shop/controller/ItemController.java
+++ b/src/main/java/com/likelion12th/shop/controller/ItemController.java
@@ -1,0 +1,68 @@
+package com.likelion12th.shop.controller;
+
+import com.likelion12th.shop.dto.ItemFormDto;
+import com.likelion12th.shop.service.ItemService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/item")
+@RequiredArgsConstructor
+public class ItemController {
+
+    private final ItemService itemService;
+
+    @PostMapping("/new")
+    public ResponseEntity<Long> createItem(@RequestPart(name = "itemFormDto") ItemFormDto itemFormDto,
+                                           @RequestPart(value = "itemImg", required = false) MultipartFile itemImg) {
+        if (itemImg == null) {
+            try {
+                // 새로운 아이템 저장
+                Long itemId = itemService.saveItem(itemFormDto);
+
+                // 저장된 아이템의 아이디 반환
+                return ResponseEntity.status(HttpStatus.CREATED).body(itemId);
+            } catch (Exception e) {
+                //예외 발생 시 처리
+                return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+            }
+        } else {
+            try {
+                // 새로운 아이템 저장
+                Long itemId = itemService.saveItem(itemFormDto, itemImg);
+
+                // 저장된 아이템의 아이디 변환
+                return ResponseEntity.status(HttpStatus.CREATED).body(itemId);
+            } catch (Exception e) {
+                // 예외 발생 시 처리
+                return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+            }
+        }
+    }
+
+    @RequestMapping
+    public ResponseEntity<List<ItemFormDto>> getItems() {
+        return ResponseEntity.ok().body(itemService.getItems());
+    }
+
+    @GetMapping("/{itemId}")
+    public ResponseEntity<ItemFormDto> getItemById(@PathVariable Long itemId) {
+        try {
+            // 아이템 Id를 사용해 특정 상품 조회
+            ItemFormDto itemFormDto = itemService.getItemById(itemId);
+            // 조회된 상품 정보 반환
+            return ResponseEntity.ok().body(itemFormDto);
+        } catch (HttpClientErrorException e) {
+            // 아이템 찾지 못할 경우 404 에러 반환
+            return ResponseEntity.status(e.getStatusCode()).body(null);
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
+    }
+}

--- a/src/main/java/com/likelion12th/shop/controller/MainController.java
+++ b/src/main/java/com/likelion12th/shop/controller/MainController.java
@@ -1,2 +1,14 @@
-package com.likelion12th.shop.controller;public class MainController {
+package com.likelion12th.shop.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+@RequiredArgsConstructor
+public class MainController {
+    @GetMapping(value="/")
+    public String main() {
+        return "main";
+    }
 }

--- a/src/main/java/com/likelion12th/shop/controller/MainController.java
+++ b/src/main/java/com/likelion12th/shop/controller/MainController.java
@@ -1,0 +1,2 @@
+package com.likelion12th.shop.controller;public class MainController {
+}

--- a/src/main/java/com/likelion12th/shop/controller/MemberController.java
+++ b/src/main/java/com/likelion12th/shop/controller/MemberController.java
@@ -1,2 +1,98 @@
-package com.likelion12th.shop.controller;public class MemberController {
+package com.likelion12th.shop.controller;
+
+import com.likelion12th.shop.constant.Role;
+import com.likelion12th.shop.dto.MemberFormDto;
+import com.likelion12th.shop.entity.Member;
+import com.likelion12th.shop.service.MemberService;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import java.io.IOException;
+import java.util.Collection;
+
+@RequestMapping("/members")
+@Controller
+@RequiredArgsConstructor
+public class MemberController {
+
+    private final MemberService memberService;
+    private final PasswordEncoder passwordEncoder;
+
+    // 요청 시 회원가입 폼 페이지로 이동
+    @GetMapping(value="/new")
+    public String memberForm(Model model) {
+        model.addAttribute("memberFormDto", new MemberFormDto());
+        return "member/memberForm";
+    }
+
+    // submit 버튼 누르면 호출되어 회원 생성
+    @PostMapping(value="/new")
+    public String memberForm(@Valid MemberFormDto memberFormDto, BindingResult bindingResult, Model model) {
+        if (bindingResult.hasErrors()) {
+            return "member/memberForm";
+        }
+        try {
+            Member member = Member.createMember(memberFormDto, passwordEncoder);
+            memberService.saveMember(member);
+        } catch (IllegalStateException e) {
+            model.addAttribute("errorMessage", e.getMessage());
+            return "member/memberForm";
+        }
+
+        return "redirect:/members/login";
+    }
+
+    @GetMapping("/login")
+    public String loginMember() {
+        return "/member/memberLoginForm";
+    }
+
+    @GetMapping("/login/error")
+    public String loginError(Model model) {
+        model.addAttribute("loginErrorMsg", "아이디 또는 비밀번호를 확인해주세요");
+        return "/member/memberLoginForm";
+    }
+
+    // 관리자 회원가입 폼 페이지로 이동
+    @GetMapping(value = "/admin")
+    public String adminMemberForm(Model model) {
+        model.addAttribute("memberFormDto", new MemberFormDto());
+        return "member/adminForm";
+    }
+
+    // 관리자 회원가입 처리
+    @PostMapping(value = "/admin")
+    public String newAdminMember(@Valid MemberFormDto memberFormDto,
+                                 BindingResult bindingResult, Model model) {
+
+        if(bindingResult.hasErrors()) {   // 에러가 있다면 회원 가입 페이지로 이동
+            return "member/adminForm";
+        }
+
+        try {
+            Member member = Member.createAdminMember(memberFormDto, passwordEncoder);
+            member.setRole(Role.ADMIN);
+            memberService.saveMember(member);
+
+        } catch (IllegalStateException e) {
+            model.addAttribute("errorMessage", e.getMessage());
+            return "member/adminForm";
+        }
+
+        return "redirect:/";
+    }
+
+
 }

--- a/src/main/java/com/likelion12th/shop/controller/MemberController.java
+++ b/src/main/java/com/likelion12th/shop/controller/MemberController.java
@@ -1,0 +1,2 @@
+package com.likelion12th.shop.controller;public class MemberController {
+}

--- a/src/main/java/com/likelion12th/shop/controller/OrderController.java
+++ b/src/main/java/com/likelion12th/shop/controller/OrderController.java
@@ -39,9 +39,9 @@ public class OrderController {
     }
 
     @GetMapping("/{orderId}")
-    public ResponseEntity<OrderItemDto> getOrderDetails(@PathVariable Long orderId, @RequestParam String email) {
-        OrderItemDto orderItemDto = orderService.getOrderDetails(orderId, email);
-        return ResponseEntity.ok(orderItemDto);
+    public ResponseEntity<List<OrderItemDto>> getOrderDetails(@PathVariable Long orderId, @RequestParam String email) {
+        List<OrderItemDto> orderItemDtos = orderService.getOrderDetails(orderId, email);
+        return ResponseEntity.ok(orderItemDtos);
     }
 
     @GetMapping("/{orderId}/cancel")

--- a/src/main/java/com/likelion12th/shop/controller/OrderController.java
+++ b/src/main/java/com/likelion12th/shop/controller/OrderController.java
@@ -1,0 +1,56 @@
+package com.likelion12th.shop.controller;
+
+import com.likelion12th.shop.dto.OrderDto;
+import com.likelion12th.shop.dto.OrderItemDto;
+import com.likelion12th.shop.dto.OrderReqDto;
+import com.likelion12th.shop.entity.Order;
+import com.likelion12th.shop.service.OrderService;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("api/orders")
+public class OrderController {
+    private final OrderService orderService;
+
+    @PostMapping("/new")
+    public ResponseEntity<String> createNewOrder(@RequestBody OrderReqDto orderReqDto,@RequestParam String email) {
+        try {
+            Long orderId = orderService.createNewOrder(orderReqDto,email);
+
+            return ResponseEntity.ok("사용자: " + email + ", 주문 ID: " + orderId);
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("주문 실패 : " + e.getMessage());
+        }
+    }
+
+    @GetMapping("/all")
+    public ResponseEntity<List<OrderDto>> getAllOrderByUserEmail(@RequestParam String email) {
+        List<OrderDto> orders = orderService.getAllOrdersByUserEmail(email);
+
+        return ResponseEntity.ok(orders);
+    }
+
+    @GetMapping("/{orderId}")
+    public ResponseEntity<OrderItemDto> getOrderDetails(@PathVariable Long orderId, @RequestParam String email) {
+        OrderItemDto orderItemDto = orderService.getOrderDetails(orderId, email);
+        return ResponseEntity.ok(orderItemDto);
+    }
+
+    @GetMapping("/{orderId}/cancel")
+    public ResponseEntity<String> cancelOrder(@PathVariable Long orderId, @RequestParam String email) {
+        try {
+            orderService.cancelOrder(orderId, email);
+            return ResponseEntity.ok("주문이 취소되었습니다.");
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("주문 취소 실패: " + e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/likelion12th/shop/dto/CartDetailDto.java
+++ b/src/main/java/com/likelion12th/shop/dto/CartDetailDto.java
@@ -1,0 +1,25 @@
+package com.likelion12th.shop.dto;
+
+import com.likelion12th.shop.entity.CartItem;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class CartDetailDto {
+    private Long cartItemId;
+    private String itemName;
+    private int itemPrice;
+    private int count;
+    private String itemImgPath;
+
+    public CartDetailDto(Long cartItemId, String itemName, int itemPrice, int count, String itemImgPath){
+        this.cartItemId = cartItemId;
+        this.itemName = itemName;
+        this.itemPrice = itemPrice;
+        this.count = count;
+        this.itemImgPath = itemImgPath;
+    }
+}

--- a/src/main/java/com/likelion12th/shop/dto/CartItemDto.java
+++ b/src/main/java/com/likelion12th/shop/dto/CartItemDto.java
@@ -1,0 +1,11 @@
+package com.likelion12th.shop.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class CartItemDto {
+    private Long itemId;
+    private int count;
+}

--- a/src/main/java/com/likelion12th/shop/dto/CartOrderDto.java
+++ b/src/main/java/com/likelion12th/shop/dto/CartOrderDto.java
@@ -1,0 +1,13 @@
+package com.likelion12th.shop.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+public class CartOrderDto {
+    private Long cartItemId;
+    private List<CartOrderDto> cartOrderDtoList;
+}

--- a/src/main/java/com/likelion12th/shop/dto/ItemFormDto.java
+++ b/src/main/java/com/likelion12th/shop/dto/ItemFormDto.java
@@ -1,0 +1,39 @@
+package com.likelion12th.shop.dto;
+
+import com.likelion12th.shop.constant.ItemSellStatus;
+import com.likelion12th.shop.entity.Item;
+import lombok.Getter;
+import lombok.Setter;
+import org.antlr.v4.runtime.misc.NotNull;
+import org.modelmapper.ModelMapper;
+
+@Getter
+@Setter
+public class ItemFormDto {
+    private  Long id;
+    @NotNull
+    private String itemName;
+    @NotNull
+    private Integer price;
+    @NotNull
+    private String itemDetail;
+    @NotNull
+    private Integer stock;
+    @NotNull
+    private ItemSellStatus itemSellStatus;
+
+    // get에서만 사용
+    private String itemImgPath;
+
+
+    private static ModelMapper modelMapper = new ModelMapper();
+    // Dto -> 엔티티 객체 변환을 위한 메서드
+    public Item createItem(){
+        return modelMapper.map(this, Item.class);
+    }
+
+    public static ItemFormDto of(Item item){
+        return modelMapper.map(item,ItemFormDto.class);
+    }
+
+}

--- a/src/main/java/com/likelion12th/shop/dto/MemberFormDto.java
+++ b/src/main/java/com/likelion12th/shop/dto/MemberFormDto.java
@@ -1,0 +1,13 @@
+package com.likelion12th.shop.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class MemberFormDto {
+    private String name;
+    private String email;
+    private String password;
+    private String address;
+}

--- a/src/main/java/com/likelion12th/shop/dto/MemberFormDto.java
+++ b/src/main/java/com/likelion12th/shop/dto/MemberFormDto.java
@@ -1,13 +1,24 @@
 package com.likelion12th.shop.dto;
 
+import jakarta.validation.constraints.*;
 import lombok.Getter;
 import lombok.Setter;
+import org.hibernate.validator.constraints.Length;
 
 @Getter
 @Setter
 public class MemberFormDto {
+    @NotBlank(message = "이름은 필수 입력 값입니다.")
     private String name;
+
+    @NotEmpty(message = "이메일은 필수 입력 값입니다.")
+    @Email(message = "이메일 형식으로 입력해주세요.")
     private String email;
+
+    @NotEmpty(message = "비밀번호는 필수 입력 값입니다.")
+    @Length(min=8, max=16, message = "비밀번호는 8자 이상, 16자 이하로 입력해주세요.")
     private String password;
+
+    @NotEmpty(message = "주소는 필수 입력 값입니다.")
     private String address;
 }

--- a/src/main/java/com/likelion12th/shop/dto/OrderDto.java
+++ b/src/main/java/com/likelion12th/shop/dto/OrderDto.java
@@ -8,6 +8,9 @@ import lombok.Setter;
 import org.modelmapper.ModelMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 @Getter
 @Setter
 @NoArgsConstructor
@@ -16,16 +19,16 @@ public class OrderDto {
     private Long orderId;
     private String orderDate;
     private OrderStatus orderStatus;
-    private Long itemId;
+    private List<Long> itemIds;
     private int totalPrice;
 
     private static ModelMapper modelMapper = new ModelMapper();
 
     public static OrderDto of(Order order){
         OrderDto orderDto = modelMapper.map(order, OrderDto.class);
-        if(!order.getOrderItemList().isEmpty()) {
-            orderDto.setItemId(order.getOrderItemList().get(0).getItem().getId());
-        }
+        orderDto.setItemIds(order.getOrderItemList().stream()
+                .map(orderItem -> orderItem.getItem().getId())
+                .collect(Collectors.toList()));
         return orderDto;
 
     }

--- a/src/main/java/com/likelion12th/shop/dto/OrderDto.java
+++ b/src/main/java/com/likelion12th/shop/dto/OrderDto.java
@@ -1,0 +1,32 @@
+package com.likelion12th.shop.dto;
+
+import com.likelion12th.shop.constant.OrderStatus;
+import com.likelion12th.shop.entity.Order;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.modelmapper.ModelMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class OrderDto {
+
+    private Long orderId;
+    private String orderDate;
+    private OrderStatus orderStatus;
+    private Long itemId;
+    private int totalPrice;
+
+    private static ModelMapper modelMapper = new ModelMapper();
+
+    public static OrderDto of(Order order){
+        OrderDto orderDto = modelMapper.map(order, OrderDto.class);
+        if(!order.getOrderItemList().isEmpty()) {
+            orderDto.setItemId(order.getOrderItemList().get(0).getItem().getId());
+        }
+        return orderDto;
+
+    }
+}

--- a/src/main/java/com/likelion12th/shop/dto/OrderItemDto.java
+++ b/src/main/java/com/likelion12th/shop/dto/OrderItemDto.java
@@ -1,0 +1,23 @@
+package com.likelion12th.shop.dto;
+
+import com.likelion12th.shop.entity.OrderItem;
+import lombok.Getter;
+import lombok.Setter;
+import org.modelmapper.ModelMapper;
+
+@Getter
+@Setter
+public class OrderItemDto {
+    private Long itemId;
+    private String itemName;
+    private Integer itemPrice;
+    private Integer count;
+    private int totalPrice;
+
+    private static ModelMapper modelMapper = new ModelMapper();
+
+    public static OrderItemDto of(OrderItem orderItem) {
+        OrderItemDto orderItemDto = modelMapper.map(orderItem, OrderItemDto.class);
+        return orderItemDto;
+    }
+}

--- a/src/main/java/com/likelion12th/shop/dto/OrderReqDto.java
+++ b/src/main/java/com/likelion12th/shop/dto/OrderReqDto.java
@@ -1,0 +1,11 @@
+package com.likelion12th.shop.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class OrderReqDto {
+    private Long itemId;
+    private Integer count;
+}

--- a/src/main/java/com/likelion12th/shop/dto/PaymentDto.java
+++ b/src/main/java/com/likelion12th/shop/dto/PaymentDto.java
@@ -1,0 +1,16 @@
+package com.likelion12th.shop.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+public class PaymentDto {
+    private Integer amount;
+    private Integer price;
+    private String paymentMethod;
+    private String customerId;
+}
+

--- a/src/main/java/com/likelion12th/shop/entity/Base.java
+++ b/src/main/java/com/likelion12th/shop/entity/Base.java
@@ -1,0 +1,2 @@
+package com.likelion12th.shop.entity;public class Base {
+}

--- a/src/main/java/com/likelion12th/shop/entity/Base.java
+++ b/src/main/java/com/likelion12th/shop/entity/Base.java
@@ -1,2 +1,22 @@
-package com.likelion12th.shop.entity;public class Base {
+package com.likelion12th.shop.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@EntityListeners(value = {AuditingEntityListener.class})
+@MappedSuperclass
+@Getter
+public abstract class Base extends BaseTime{
+    @CreatedBy
+    @Column(updatable = false)
+    private String createdBy;
+
+    @LastModifiedBy
+    private String modifiedBy;
 }

--- a/src/main/java/com/likelion12th/shop/entity/BaseTime.java
+++ b/src/main/java/com/likelion12th/shop/entity/BaseTime.java
@@ -1,0 +1,35 @@
+package com.likelion12th.shop.entity;
+
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@EntityListeners(value = {AuditingEntityListener.class})
+@MappedSuperclass
+@Getter @Setter
+public abstract class BaseTime {
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime regTime;
+
+    @LastModifiedDate
+    @Column(updatable = false)
+    private LocalDateTime updateTime;
+
+    @CreatedBy
+    @Column(updatable = false)
+    private String createdBy;
+
+    @LastModifiedBy
+    private String modifiedBy;
+}

--- a/src/main/java/com/likelion12th/shop/entity/BaseTime.java
+++ b/src/main/java/com/likelion12th/shop/entity/BaseTime.java
@@ -6,6 +6,7 @@ import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
 import lombok.Getter;
 import lombok.Setter;
+import lombok.ToString;
 import org.springframework.data.annotation.CreatedBy;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedBy;
@@ -17,6 +18,7 @@ import java.time.LocalDateTime;
 @EntityListeners(value = {AuditingEntityListener.class})
 @MappedSuperclass
 @Getter @Setter
+@ToString
 public abstract class BaseTime {
     @CreatedDate
     @Column(updatable = false)
@@ -26,10 +28,10 @@ public abstract class BaseTime {
     @Column(updatable = false)
     private LocalDateTime updateTime;
 
-    @CreatedBy
-    @Column(updatable = false)
-    private String createdBy;
+    //@CreatedBy
+    //@Column(updatable = false)
+    //private String createdBy;
 
-    @LastModifiedBy
-    private String modifiedBy;
+    //@LastModifiedBy
+    //private String modifiedBy;
 }

--- a/src/main/java/com/likelion12th/shop/entity/Cart.java
+++ b/src/main/java/com/likelion12th/shop/entity/Cart.java
@@ -21,4 +21,10 @@ public class Cart {
     @OneToOne
     @JoinColumn(name = "member_id") // cart 테이블에 외래키 이름 지정
     private Member member;
+
+    public static Cart createCart(Member member) {
+        Cart cart = new Cart();
+        cart.setMember(member);
+        return cart;
+    }
 }

--- a/src/main/java/com/likelion12th/shop/entity/Cart.java
+++ b/src/main/java/com/likelion12th/shop/entity/Cart.java
@@ -1,4 +1,24 @@
 package com.likelion12th.shop.entity;
 
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table
+@Getter
+@Setter
 public class Cart {
+    @Id
+    @Column(name = "cart_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private LocalDateTime createdBy;
+    private LocalDateTime modifiedBy;
+
+    @OneToOne
+    @JoinColumn(name = "member_id") // cart 테이블에 외래키 이름 지정
+    private Member member;
 }

--- a/src/main/java/com/likelion12th/shop/entity/CartItem.java
+++ b/src/main/java/com/likelion12th/shop/entity/CartItem.java
@@ -29,4 +29,20 @@ public class CartItem {
     private Integer count;
     private LocalDateTime createdBy;
     private LocalDateTime modifiedBy;
+
+    public static CartItem createCartItem(Cart cart, Item item, int count) {
+        CartItem cartItem = new CartItem();
+        cartItem.setCart(cart);
+        cartItem.setItem(item);
+        cartItem.setCount(count);
+        return cartItem;
+    }
+
+    public void addCount(int count){
+        this.count += count;
+    }
+
+    public void updateCount(int count){
+        this.count = count;
+    }
 }

--- a/src/main/java/com/likelion12th/shop/entity/CartItem.java
+++ b/src/main/java/com/likelion12th/shop/entity/CartItem.java
@@ -1,4 +1,32 @@
 package com.likelion12th.shop.entity;
 
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table
+@Getter
+@Setter
 public class CartItem {
+    @Id
+    @Column(name = "cartitem_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    //Cart
+    @ManyToOne
+    @JoinColumn(name = "cart_id")
+    private Cart cart;
+
+    //Item
+    @ManyToOne
+    @JoinColumn(name = "item_id")
+    private Item item;
+
+    private Integer count;
+    private LocalDateTime createdBy;
+    private LocalDateTime modifiedBy;
 }

--- a/src/main/java/com/likelion12th/shop/entity/Item.java
+++ b/src/main/java/com/likelion12th/shop/entity/Item.java
@@ -7,6 +7,8 @@ import lombok.Setter;
 import lombok.ToString;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Table
@@ -22,10 +24,15 @@ public class Item {
     private Integer price;
     private Integer stock;
     private String itemDetail;
+    private String itemImg;
+    private String itemImgPath;
 
     @Enumerated(EnumType.STRING)
     private com.likelion12th.shop.constant.itemSellStatus itemSellStatus;
 
     private LocalDateTime createdBy;
     private LocalDateTime modifiedBy;
+
+    @OneToMany(mappedBy = "item", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<OrderItem> orderItemList = new ArrayList<>();
 }

--- a/src/main/java/com/likelion12th/shop/entity/Item.java
+++ b/src/main/java/com/likelion12th/shop/entity/Item.java
@@ -4,6 +4,7 @@ import com.likelion12th.shop.constant.OrderStatus;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
+import lombok.ToString;
 
 import java.time.LocalDateTime;
 
@@ -11,6 +12,7 @@ import java.time.LocalDateTime;
 @Table
 @Getter
 @Setter
+@ToString
 public class Item {
     @Id
     @Column(name = "item_id")

--- a/src/main/java/com/likelion12th/shop/entity/Item.java
+++ b/src/main/java/com/likelion12th/shop/entity/Item.java
@@ -1,6 +1,5 @@
 package com.likelion12th.shop.entity;
 
-import com.likelion12th.shop.constant.OrderStatus;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
@@ -28,7 +27,7 @@ public class Item {
     private String itemImgPath;
 
     @Enumerated(EnumType.STRING)
-    private com.likelion12th.shop.constant.itemSellStatus itemSellStatus;
+    private com.likelion12th.shop.constant.ItemSellStatus ItemSellStatus;
 
     private LocalDateTime createdBy;
     private LocalDateTime modifiedBy;

--- a/src/main/java/com/likelion12th/shop/entity/Item.java
+++ b/src/main/java/com/likelion12th/shop/entity/Item.java
@@ -1,4 +1,29 @@
 package com.likelion12th.shop.entity;
 
+import com.likelion12th.shop.constant.OrderStatus;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table
+@Getter
+@Setter
 public class Item {
+    @Id
+    @Column(name = "item_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String itemName;
+    private Integer price;
+    private Integer stock;
+    private String itemDetail;
+
+    @Enumerated(EnumType.STRING)
+    private com.likelion12th.shop.constant.itemSellStatus itemSellStatus;
+
+    private LocalDateTime createdBy;
+    private LocalDateTime modifiedBy;
 }

--- a/src/main/java/com/likelion12th/shop/entity/Item.java
+++ b/src/main/java/com/likelion12th/shop/entity/Item.java
@@ -1,5 +1,6 @@
 package com.likelion12th.shop.entity;
 
+import com.likelion12th.shop.exception.OutOfStockException;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
@@ -34,4 +35,18 @@ public class Item {
 
     @OneToMany(mappedBy = "item", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<OrderItem> orderItemList = new ArrayList<>();
+
+    public void removeStock(int stock) {
+        int restStock = this.stock - stock;
+        if(restStock<0) {
+            throw new OutOfStockException("상품의 재고가 부족합니다. (현재 재고 수량 : " + this.stock + ")");
+        }
+        this.stock = restStock;
+    }
+
+    public void addStock(int stock) {
+        this.stock += stock;
+    }
 }
+
+

--- a/src/main/java/com/likelion12th/shop/entity/Member.java
+++ b/src/main/java/com/likelion12th/shop/entity/Member.java
@@ -1,6 +1,45 @@
 package com.likelion12th.shop.entity;
+import com.likelion12th.shop.constant.Role;
+import com.likelion12th.shop.dto.MemberFormDto;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+import org.springframework.stereotype.Service;
 
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name="member")
+@Getter @Setter
+@ToString // 이거 설정 안하면 실행했을 때 ?로 뜸
 public class Member {
+    @Id
+    @Column(name="member_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String name;
 
+    @Column(unique = true)
+    private String email;
+    private String password;
+    private String address;
+
+    @Enumerated(EnumType.STRING)
+    private Role role;
+
+    private LocalDateTime createdBy;
+    private LocalDateTime modifiedBy;
+
+    public static Member createMember(MemberFormDto memberFormDto) {
+        Member member = new Member();
+        member.setName(memberFormDto.getName());
+        member.setEmail(memberFormDto.getEmail());
+        member.setPassword(memberFormDto.getPassword());
+        member.setAddress(memberFormDto.getAddress());
+
+        return member;
+    }
 
 }
+

--- a/src/main/java/com/likelion12th/shop/entity/Member.java
+++ b/src/main/java/com/likelion12th/shop/entity/Member.java
@@ -5,15 +5,19 @@ import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
 
 @Entity
 @Table(name="member")
+@EntityListeners(AuditingEntityListener.class)
 @Getter @Setter
 @ToString // 이거 설정 안하면 실행했을 때 ?로 뜸
-public class Member {
+public class Member extends BaseTime{
     @Id
     @Column(name="member_id")
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -28,8 +32,11 @@ public class Member {
     @Enumerated(EnumType.STRING)
     private Role role;
 
-    private LocalDateTime createdBy;
-    private LocalDateTime modifiedBy;
+    @CreatedBy
+    private String createdBy;
+
+    @LastModifiedBy
+    private String modifiedBy;
 
     public static Member createMember(MemberFormDto memberFormDto) {
         Member member = new Member();

--- a/src/main/java/com/likelion12th/shop/entity/Member.java
+++ b/src/main/java/com/likelion12th/shop/entity/Member.java
@@ -8,6 +8,7 @@ import lombok.ToString;
 import org.springframework.data.annotation.CreatedBy;
 import org.springframework.data.annotation.LastModifiedBy;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
@@ -22,6 +23,7 @@ public class Member extends BaseTime{
     @Column(name="member_id")
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
     private String name;
 
     @Column(unique = true)
@@ -38,14 +40,29 @@ public class Member extends BaseTime{
     @LastModifiedBy
     private String modifiedBy;
 
-    public static Member createMember(MemberFormDto memberFormDto) {
+    public static Member createMember(MemberFormDto memberFormDto, PasswordEncoder passwordEncoder) {
         Member member = new Member();
         member.setName(memberFormDto.getName());
         member.setEmail(memberFormDto.getEmail());
-        member.setPassword(memberFormDto.getPassword());
+        String pwd = passwordEncoder.encode(memberFormDto.getPassword());
+        member.setPassword(pwd);
+        member.setRole(Role.USER);
         member.setAddress(memberFormDto.getAddress());
 
         return member;
+    }
+
+    public static Member createAdminMember(MemberFormDto memberFormDto,
+                                           PasswordEncoder passwordEncoder) {
+
+        Member adminmember = new Member();
+        adminmember.setName(memberFormDto.getName());
+        adminmember.setEmail(memberFormDto.getEmail());
+        adminmember.setAddress(memberFormDto.getAddress());
+        String password = passwordEncoder.encode(memberFormDto.getPassword());
+        adminmember.setPassword(password);
+        adminmember.setRole(Role.ADMIN);
+        return adminmember;
     }
 
 }

--- a/src/main/java/com/likelion12th/shop/entity/Order.java
+++ b/src/main/java/com/likelion12th/shop/entity/Order.java
@@ -1,6 +1,8 @@
 package com.likelion12th.shop.entity;
 
 import com.likelion12th.shop.constant.OrderStatus;
+import com.likelion12th.shop.repository.MemberRepository;
+import com.likelion12th.shop.repository.OrderRepository;
 import jakarta.persistence.*;
 import jakarta.transaction.Transactional;
 import lombok.Getter;
@@ -25,7 +27,7 @@ public class Order {
     private LocalDateTime OrderDate;
 
     @Enumerated(EnumType.STRING)
-    private OrderStatus OrderStatus;
+    private OrderStatus orderStatus;
 
     private LocalDateTime createdBy;
     private LocalDateTime modifiedBy;
@@ -42,8 +44,36 @@ public class Order {
     //private List<OrderItem> orderItems = new ArrayList<>();
 
     public void addOrderItem(OrderItem orderItem) {
-        this.orderItemList.add(orderItem);
+        orderItemList.add(orderItem);
         orderItem.setOrder(this);
+    }
+
+    public static Order createOrder(Member member, List<OrderItem> orderItemList) {
+        Order order = new Order();
+        order.setMember(member);
+
+        for(OrderItem orderItem : orderItemList) {
+            order.addOrderItem(orderItem);
+        }
+
+        order.setOrderStatus(com.likelion12th.shop.constant.OrderStatus.ORDER);
+        order.setOrderDate(LocalDateTime.now());
+        return order;
+    }
+
+    public int getTotalPrice() {
+        int totalPrice = 0;
+        for(OrderItem orderItem : orderItemList) {
+            totalPrice += orderItem.getTotalPrice();
+        }
+        return totalPrice;
+    }
+
+    public void cancelOrder() {
+        this.orderStatus = OrderStatus.CANCEL;
+        for (OrderItem orderItem : orderItemList) {
+            orderItem.cancel();
+        }
     }
 }
 

--- a/src/main/java/com/likelion12th/shop/entity/Order.java
+++ b/src/main/java/com/likelion12th/shop/entity/Order.java
@@ -1,4 +1,31 @@
 package com.likelion12th.shop.entity;
 
+import com.likelion12th.shop.constant.OrderStatus;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name="orders")
+@Getter
+@Setter
 public class Order {
+    @Id
+    @Column(name = "order_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private LocalDateTime OrderDate;
+
+    @Enumerated(EnumType.STRING)
+    private OrderStatus OrderStatus;
+
+    private LocalDateTime createdBy;
+    private LocalDateTime modifiedBy;
+
+    // 주문 회원
+    @ManyToOne
+    @JoinColumn(name = "member_id") // member_id라는 컬럼으로 저 member랑 조인을 하겠다.
+    private Member member;
 }

--- a/src/main/java/com/likelion12th/shop/entity/Order.java
+++ b/src/main/java/com/likelion12th/shop/entity/Order.java
@@ -2,8 +2,10 @@ package com.likelion12th.shop.entity;
 
 import com.likelion12th.shop.constant.OrderStatus;
 import jakarta.persistence.*;
+import jakarta.transaction.Transactional;
 import lombok.Getter;
 import lombok.Setter;
+import lombok.ToString;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -13,6 +15,8 @@ import java.util.List;
 @Table(name="orders")
 @Getter
 @Setter
+@ToString
+@Transactional
 public class Order {
     @Id
     @Column(name = "order_id")
@@ -31,6 +35,16 @@ public class Order {
     @JoinColumn(name = "member_id") // member_id라는 컬럼으로 저 member랑 조인을 하겠다.
     private Member member;
 
-    @OneToMany(mappedBy = "order", cascade = CascadeType.ALL)
-    private List<OrderItem> orderItems = new ArrayList<>();
+    @OneToMany(mappedBy = "order", cascade = CascadeType.ALL, orphanRemoval = true)
+    List<OrderItem> orderItemList = new ArrayList<>();
+
+    //@OneToMany(mappedBy = "order", cascade = CascadeType.ALL)
+    //private List<OrderItem> orderItems = new ArrayList<>();
+
+    public void addOrderItem(OrderItem orderItem) {
+        this.orderItemList.add(orderItem);
+        orderItem.setOrder(this);
+    }
 }
+
+

--- a/src/main/java/com/likelion12th/shop/entity/Order.java
+++ b/src/main/java/com/likelion12th/shop/entity/Order.java
@@ -6,6 +6,8 @@ import lombok.Getter;
 import lombok.Setter;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Table(name="orders")
@@ -28,4 +30,7 @@ public class Order {
     @ManyToOne
     @JoinColumn(name = "member_id") // member_id라는 컬럼으로 저 member랑 조인을 하겠다.
     private Member member;
+
+    @OneToMany(mappedBy = "order", cascade = CascadeType.ALL)
+    private List<OrderItem> orderItems = new ArrayList<>();
 }

--- a/src/main/java/com/likelion12th/shop/entity/OrderItem.java
+++ b/src/main/java/com/likelion12th/shop/entity/OrderItem.java
@@ -5,6 +5,7 @@ import jakarta.transaction.Transactional;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
+import org.aspectj.weaver.ast.Or;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
@@ -33,4 +34,23 @@ public class OrderItem {
     private int count;
     private LocalDateTime createdBy;
     private LocalDateTime modifiedBy;
+
+    public static OrderItem createOrderItem (Item item, int count) {
+        OrderItem orderItem = new OrderItem();
+
+        orderItem.setItem(item);
+        orderItem.setCount(count);
+        orderItem.setOrderPrice(item.getPrice());
+
+        item.removeStock(count);
+        return orderItem;
+    }
+
+    public int getTotalPrice() {
+        return orderPrice * count;
+    }
+
+    public void cancel() {
+        this.getItem().addStock(count);
+    }
 }

--- a/src/main/java/com/likelion12th/shop/entity/OrderItem.java
+++ b/src/main/java/com/likelion12th/shop/entity/OrderItem.java
@@ -1,33 +1,36 @@
 package com.likelion12th.shop.entity;
 
 import jakarta.persistence.*;
+import jakarta.transaction.Transactional;
 import lombok.Getter;
 import lombok.Setter;
+import lombok.ToString;
 
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 
 @Entity
-@Table
+@Table(name = "order_item") // 테이블 이름 지정
 @Getter
 @Setter
+@ToString
+@Transactional
 public class OrderItem {
     @Id
-    @Column(name = "orderitem_id")
+    @Column(name = "order_item_id")
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    //Order
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "order_id")
     private Order order;
 
-    //Item
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "item_id")
     private Item item;
 
-    private Integer orderPrice;
-    private Integer count;
+    private int orderPrice;
+    private int count;
     private LocalDateTime createdBy;
     private LocalDateTime modifiedBy;
 }

--- a/src/main/java/com/likelion12th/shop/entity/Payment.java
+++ b/src/main/java/com/likelion12th/shop/entity/Payment.java
@@ -3,31 +3,30 @@ package com.likelion12th.shop.entity;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
+import lombok.ToString;
 
 import java.time.LocalDateTime;
 
 @Entity
-@Table
+@Table(name="payment")
 @Getter
 @Setter
-public class OrderItem {
+@ToString
+public class Payment {
     @Id
-    @Column(name = "orderitem_id")
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    //Order
     @ManyToOne
     @JoinColumn(name = "order_id")
     private Order order;
 
-    //Item
-    @ManyToOne
-    @JoinColumn(name = "item_id")
-    private Item item;
+    private Integer amount;
+    private Integer price;
+    private String paymentMethod;
+    private String customerId;
 
-    private Integer orderPrice;
-    private Integer count;
     private LocalDateTime createdBy;
     private LocalDateTime modifiedBy;
 }
+

--- a/src/main/java/com/likelion12th/shop/exception/OutOfStockException.java
+++ b/src/main/java/com/likelion12th/shop/exception/OutOfStockException.java
@@ -1,0 +1,7 @@
+package com.likelion12th.shop.exception;
+
+public class OutOfStockException extends RuntimeException{
+    public OutOfStockException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/likelion12th/shop/repository/CartItemRepository.java
+++ b/src/main/java/com/likelion12th/shop/repository/CartItemRepository.java
@@ -1,0 +1,18 @@
+package com.likelion12th.shop.repository;
+
+import com.likelion12th.shop.dto.CartDetailDto;
+import com.likelion12th.shop.entity.CartItem;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface CartItemRepository extends JpaRepository<CartItem, Long> {
+    CartItem findByCartIdAndItemId(Long cartId, Long itemId);
+
+    @Query("SELECT new com.likelion12th.shop.dto.CartDetailDto(ci.id, ci.item.itemName, ci.item.price, ci.count, ci.item.itemImgPath) " +
+            "FROM CartItem ci " +
+            "WHERE ci.cart.id = :cartId")
+    List<CartDetailDto> findCartOrderList(@Param("cartId") Long cartId);
+}

--- a/src/main/java/com/likelion12th/shop/repository/CartRepository.java
+++ b/src/main/java/com/likelion12th/shop/repository/CartRepository.java
@@ -1,0 +1,11 @@
+package com.likelion12th.shop.repository;
+
+import com.likelion12th.shop.entity.Cart;
+import com.likelion12th.shop.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface CartRepository extends JpaRepository<Cart, Long> {
+    Cart findByMember(Member member);
+}

--- a/src/main/java/com/likelion12th/shop/repository/ItemRepository.java
+++ b/src/main/java/com/likelion12th/shop/repository/ItemRepository.java
@@ -14,4 +14,6 @@ public interface ItemRepository extends JpaRepository<Item, Long> {
 
     @Query("select i from Item i where i.itemDetail like " + "%:itemDetail% order by i.price desc")
     List<Item> findByItemDetail(@Param("itemDetail") String itemDetail);
+
+    List<Item> findByItemNameContainingIgnoreCase(String itemName);
 }

--- a/src/main/java/com/likelion12th/shop/repository/ItemRepository.java
+++ b/src/main/java/com/likelion12th/shop/repository/ItemRepository.java
@@ -1,0 +1,17 @@
+package com.likelion12th.shop.repository;
+
+import com.likelion12th.shop.entity.Item;
+import com.likelion12th.shop.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface ItemRepository extends JpaRepository<Item, Long> {
+    List<Item> findByItemName(String itemName);
+    List<Item> findByPriceLessThanOrderByPriceDesc(Integer price);
+
+    @Query("select i from Item i where i.itemDetail like " + "%:itemDetail% order by i.price desc")
+    List<Item> findByItemDetail(@Param("itemDetail") String itemDetail);
+}

--- a/src/main/java/com/likelion12th/shop/repository/MemberRepository.java
+++ b/src/main/java/com/likelion12th/shop/repository/MemberRepository.java
@@ -4,5 +4,5 @@ import com.likelion12th.shop.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
-
+    Member findByEmail(String email);
 }

--- a/src/main/java/com/likelion12th/shop/repository/MemberRepository.java
+++ b/src/main/java/com/likelion12th/shop/repository/MemberRepository.java
@@ -1,0 +1,8 @@
+package com.likelion12th.shop.repository;
+
+import com.likelion12th.shop.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+
+}

--- a/src/main/java/com/likelion12th/shop/repository/OrderItemRepository.java
+++ b/src/main/java/com/likelion12th/shop/repository/OrderItemRepository.java
@@ -1,0 +1,11 @@
+package com.likelion12th.shop.repository;
+
+import com.likelion12th.shop.entity.OrderItem;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface OrderItemRepository extends JpaRepository<OrderItem, Long> {
+    Optional<OrderItem> findById(Long orderItemId);
+}

--- a/src/main/java/com/likelion12th/shop/repository/OrderRepository.java
+++ b/src/main/java/com/likelion12th/shop/repository/OrderRepository.java
@@ -4,5 +4,8 @@ import com.likelion12th.shop.entity.Member;
 import com.likelion12th.shop.entity.Order;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface OrderRepository extends JpaRepository<Order, Long> {
+    List<Order> findByMemberEmail(String email);
 }

--- a/src/main/java/com/likelion12th/shop/repository/OrderRepository.java
+++ b/src/main/java/com/likelion12th/shop/repository/OrderRepository.java
@@ -1,0 +1,8 @@
+package com.likelion12th.shop.repository;
+
+import com.likelion12th.shop.entity.Member;
+import com.likelion12th.shop.entity.Order;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OrderRepository extends JpaRepository<Order, Long> {
+}

--- a/src/main/java/com/likelion12th/shop/repository/PaymentRepository.java
+++ b/src/main/java/com/likelion12th/shop/repository/PaymentRepository.java
@@ -1,0 +1,7 @@
+package com.likelion12th.shop.repository;
+
+import com.likelion12th.shop.entity.Payment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PaymentRepository extends JpaRepository<Payment, Long> {
+}

--- a/src/main/java/com/likelion12th/shop/service/CartService.java
+++ b/src/main/java/com/likelion12th/shop/service/CartService.java
@@ -1,0 +1,135 @@
+package com.likelion12th.shop.service;
+
+import com.likelion12th.shop.dto.CartDetailDto;
+import com.likelion12th.shop.dto.CartItemDto;
+import com.likelion12th.shop.dto.CartOrderDto;
+import com.likelion12th.shop.dto.OrderReqDto;
+import com.likelion12th.shop.entity.Cart;
+import com.likelion12th.shop.entity.CartItem;
+import com.likelion12th.shop.entity.Item;
+import com.likelion12th.shop.entity.Member;
+import com.likelion12th.shop.repository.CartItemRepository;
+import com.likelion12th.shop.repository.CartRepository;
+import com.likelion12th.shop.repository.ItemRepository;
+import com.likelion12th.shop.repository.MemberRepository;
+import jakarta.persistence.EntityNotFoundException;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class CartService {
+    private final CartRepository cartRepository;
+    private final CartItemRepository cartItemRepository;
+    private final ItemRepository itemRepository;
+    private final MemberRepository memberRepository;
+    private final OrderService orderService;
+
+    public Long addCartItems(String email, List<CartItemDto> cartItemDtos){
+        Member member = memberRepository.findByEmail(email);
+
+        if(member == null) {
+            Member newMember = new Member();
+            newMember.setEmail(email);
+            member = memberRepository.save(newMember);
+        }
+
+        Cart cart = cartRepository.findByMember(member);
+
+        if(cart == null) {
+            cart = Cart.createCart(member);
+            cartRepository.save(cart);
+        }
+
+        Long saveItemId = null;
+        for(CartItemDto cartItemDto : cartItemDtos) {
+            Item item = itemRepository.findById(cartItemDto.getItemId())
+                    .orElseThrow(()->new IllegalArgumentException("아이템 ID가 없음"));
+
+            CartItem savedCartItem = cartItemRepository.findByCartIdAndItemId(cart.getId(), item.getId());
+
+            if (savedCartItem != null) {
+                savedCartItem.addCount(cartItemDto.getCount());
+                saveItemId = savedCartItem.getId();
+            } else {
+                CartItem newCartItem = CartItem.createCartItem(cart,item,cartItemDto.getCount());
+                CartItem savedItem = cartItemRepository.save(newCartItem);
+                saveItemId = savedItem.getId();
+            }
+        }
+        return saveItemId;
+    }
+
+    public List<CartDetailDto> getCartList(String email) {
+        List<CartDetailDto> cartDetailDtoList = new ArrayList<>();
+
+        Member member = memberRepository.findByEmail(email);
+        Cart cart = cartRepository.findByMember(member);
+        if(cart == null) {
+            return cartDetailDtoList;
+        }
+
+        cartDetailDtoList = cartItemRepository.findCartOrderList(cart.getId());
+        return cartDetailDtoList;
+    }
+
+    public void deleteCartItem(String email, Long cartItemId){
+        CartItem cartItem = cartItemRepository.findById(cartItemId)
+                .orElseThrow(EntityNotFoundException::new);
+
+        if(!cartItem.getCart().getMember().getEmail().equals(email)){
+            throw new IllegalArgumentException();
+        }
+
+        cartItemRepository.delete(cartItem);
+    }
+
+    public void updateCartItemCount(String email, CartDetailDto cartDetailDto) {
+        CartItem cartItem = cartItemRepository.findById(cartDetailDto.getCartItemId())
+                .orElseThrow(EntityNotFoundException::new);
+
+        if(!cartItem.getCart().getMember().getEmail().equals(email)) {
+            throw new IllegalArgumentException();
+        }
+
+        cartItem.updateCount(cartDetailDto.getCount());
+    }
+
+    public Long orderCartItem(String email, List<CartOrderDto> cartOrderDtoList) {
+        Member member = memberRepository.findByEmail(email);
+        if(member == null) {
+            throw new EntityNotFoundException("사용자가 존재하지 않음 : " + email);
+        }
+
+        Cart cart = cartRepository.findByMember(member);
+        if (cart == null) {
+            throw new EntityNotFoundException("사용자의 장바구니가 존재하지 않음 : " + email);
+        }
+        List<OrderReqDto> orderDtoList = new ArrayList<>();
+
+        for(CartOrderDto cartOrderDto : cartOrderDtoList) {
+            CartItem cartItem = cartItemRepository.findById(cartOrderDto.getCartItemId())
+                    .orElseThrow(EntityNotFoundException::new);
+
+            OrderReqDto orderReqDto = new OrderReqDto();
+            orderReqDto.setItemId(cartItem.getItem().getId());
+            orderReqDto.setCount(cartItem.getCount());
+
+            orderDtoList.add(orderReqDto);
+        }
+        Long orderId = orderService.orders(orderDtoList, email);
+        for(CartOrderDto cartOrderDto : cartOrderDtoList) {
+            // 장바구니 아이템 ID로 장바구니 아이템 조회
+            CartItem cartItem = cartItemRepository.findById(cartOrderDto.getCartItemId())
+                    .orElseThrow(EntityNotFoundException::new);
+            cartItemRepository.delete(cartItem);
+        }
+        return orderId;
+    }
+}

--- a/src/main/java/com/likelion12th/shop/service/ItemService.java
+++ b/src/main/java/com/likelion12th/shop/service/ItemService.java
@@ -73,4 +73,60 @@ public class ItemService {
         }
     }
 
+    // 상품명으로 상품 조회
+    public List<ItemFormDto> getItemsByName(String itemName) {
+        List<Item> items = itemRepository.findByItemNameContainingIgnoreCase(itemName);
+        List<ItemFormDto> itemFormDtos = new ArrayList<>();
+        items.forEach(s -> itemFormDtos.add(ItemFormDto.of(s)));
+        return itemFormDtos;
+    }
+
+    // 상품 수정
+    public void updateItem(Long itemId, ItemFormDto itemFormDto, MultipartFile itemImg) throws Exception {
+        Optional<Item> optionalItem = itemRepository.findById(itemId);
+
+        if (optionalItem.isPresent()) {
+            Item item = itemFormDto.createItem();
+
+            if (itemFormDto.getItemName() != null) {
+                item.setItemName(itemFormDto.getItemName());
+            }
+            if (itemFormDto.getPrice() != null) {
+                item.setPrice(itemFormDto.getPrice());
+            }
+            if (itemFormDto.getItemDetail() != null) {
+                item.setItemDetail(itemFormDto.getItemDetail());
+            }
+            if (itemFormDto.getItemSellStatus() != null) {
+                item.setItemSellStatus(itemFormDto.getItemSellStatus());
+            }
+            if (itemFormDto.getStock() != null) {
+                item.setStock(itemFormDto.getStock());
+            }
+            if (itemImg != null) {
+                UUID uuid = UUID.randomUUID();
+                String fileName = uuid.toString() + "-" + itemImg.getOriginalFilename();
+                File itemImgFile = new File(uploadPath, fileName);
+                itemImg.transferTo(itemImgFile);
+                item.setItemImg(fileName);
+                item.setItemImgPath(uploadPath + "/" + fileName);
+            }
+
+            itemRepository.save(item);
+        } else {
+            throw new HttpClientErrorException(HttpStatus.NOT_FOUND, "ID에 해당하는 상품을 찾을 수 없습니다." + itemId);
+        }
+    }
+
+    // 상품 삭제
+    public void deleteItem(Long itemId) {
+        Optional<Item> optionalItem = itemRepository.findById(itemId);
+
+        if (optionalItem.isPresent()) {
+            itemRepository.delete(optionalItem.get());
+        } else {
+            throw new HttpClientErrorException(HttpStatus.NOT_FOUND, "ID에 해당하는 상품을 찾을 수 없습니다." + itemId);
+        }
+    }
+
 }

--- a/src/main/java/com/likelion12th/shop/service/ItemService.java
+++ b/src/main/java/com/likelion12th/shop/service/ItemService.java
@@ -128,5 +128,4 @@ public class ItemService {
             throw new HttpClientErrorException(HttpStatus.NOT_FOUND, "ID에 해당하는 상품을 찾을 수 없습니다." + itemId);
         }
     }
-
 }

--- a/src/main/java/com/likelion12th/shop/service/ItemService.java
+++ b/src/main/java/com/likelion12th/shop/service/ItemService.java
@@ -1,0 +1,76 @@
+package com.likelion12th.shop.service;
+
+
+import com.likelion12th.shop.dto.ItemFormDto;
+import com.likelion12th.shop.entity.Item;
+import com.likelion12th.shop.repository.ItemRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ItemService {
+
+
+    @Autowired
+    private final ItemRepository itemRepository;
+
+    public Long saveItem(ItemFormDto itemFormDto) throws Exception {
+        //상품 등록
+        Item item = itemFormDto.createItem();
+
+        itemRepository.save(item);
+
+        return item.getId();
+    }
+
+    @Value("${uploadPath}")
+    private String uploadPath;
+
+    public Long saveItem(ItemFormDto itemFormDto, MultipartFile itemImg) throws Exception {
+        Item item = itemFormDto.createItem();
+        UUID uuid = UUID.randomUUID();
+        String fileName = uuid.toString() + "-" + itemImg.getOriginalFilename();
+        File itemImgFile = new File(uploadPath, fileName);
+        itemImg.transferTo(itemImgFile);
+        item.setItemImg(fileName);
+        item.setItemImgPath(uploadPath+"/"+fileName);
+        itemRepository.save(item);
+
+        return item.getId();
+    }
+
+    public List<ItemFormDto> getItems() {
+        List<Item> items = itemRepository.findAll(); // 모든 Item 리스트를 조회해 Item 타입의 리스트에 저장
+        List<ItemFormDto> itemFormDtos = new ArrayList<>();
+        items.forEach(s -> itemFormDtos.add(ItemFormDto.of(s)));
+        return itemFormDtos;
+    }
+
+    public ItemFormDto getItemById(Long itemId) {
+        // 아이템 ID로 아이템을 조회
+        Optional<Item> optionalItem = itemRepository.findById(itemId);
+
+        if(optionalItem.isPresent()) {
+            // 아이템 찾았을 경우 ItemFormDto로 반환
+            return ItemFormDto.of(optionalItem.get());
+        } else {
+            throw new HttpClientErrorException(HttpStatus.NOT_FOUND, "ID에 해당하는 상품을 찾을 수 없습니다. " + itemId);
+        }
+    }
+
+}

--- a/src/main/java/com/likelion12th/shop/service/MemberService.java
+++ b/src/main/java/com/likelion12th/shop/service/MemberService.java
@@ -1,2 +1,45 @@
-package com.likelion12th.shop.service;public class MemberService {
+package com.likelion12th.shop.service;
+
+
+import com.likelion12th.shop.entity.Member;
+import com.likelion12th.shop.repository.MemberRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class MemberService implements UserDetailsService {
+    private final MemberRepository memberRepository;
+    @Override
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        Member member = memberRepository.findByEmail(email); // 이메일로 데이터베이스에서 유저 찾기
+
+        if (member == null) {
+            throw new UsernameNotFoundException(email);
+        }
+
+        return User.builder()
+                .username(member.getEmail())
+                .password(member.getPassword())
+                .roles(member.getRole().toString())
+                .build();
+    }
+
+    public Member saveMember(Member member){
+        validateDuplicateMember(member);
+        return memberRepository.save(member);
+    }
+
+    private void validateDuplicateMember(Member member) {
+        Member findMember = memberRepository.findByEmail(member.getEmail());
+        if(findMember != null){
+            throw new IllegalStateException("이미 가입된 회원입니다.");
+        }
+    }
 }

--- a/src/main/java/com/likelion12th/shop/service/MemberService.java
+++ b/src/main/java/com/likelion12th/shop/service/MemberService.java
@@ -1,0 +1,2 @@
+package com.likelion12th.shop.service;public class MemberService {
+}

--- a/src/main/java/com/likelion12th/shop/service/OrderService.java
+++ b/src/main/java/com/likelion12th/shop/service/OrderService.java
@@ -1,0 +1,107 @@
+package com.likelion12th.shop.service;
+
+import com.likelion12th.shop.constant.OrderStatus;
+import com.likelion12th.shop.dto.MemberFormDto;
+import com.likelion12th.shop.dto.OrderDto;
+import com.likelion12th.shop.dto.OrderItemDto;
+import com.likelion12th.shop.dto.OrderReqDto;
+import com.likelion12th.shop.entity.Item;
+import com.likelion12th.shop.entity.Member;
+import com.likelion12th.shop.entity.Order;
+import com.likelion12th.shop.entity.OrderItem;
+import com.likelion12th.shop.repository.ItemRepository;
+import com.likelion12th.shop.repository.MemberRepository;
+import com.likelion12th.shop.repository.OrderItemRepository;
+import com.likelion12th.shop.repository.OrderRepository;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.antlr.v4.runtime.misc.NotNull;
+import org.aspectj.weaver.ast.Or;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class OrderService {
+    @Autowired
+    private final OrderRepository orderRepository;
+    @Autowired
+    private final ItemRepository itemRepository;
+    @Autowired
+    private final MemberRepository memberRepository;
+
+    public Long createNewOrder(OrderReqDto orderReqDto, String email) {
+        Member member = memberRepository.findByEmail(email);
+
+        if (member == null) {
+            Member member1 = new Member();
+            member1.setEmail(email);
+            member=memberRepository.save(member1);
+        }
+
+        Long itemId = orderReqDto.getItemId();
+        Item item = itemRepository.findById(itemId)
+                .orElseThrow(()->new IllegalArgumentException("상품 ID 없음 : " + itemId));
+
+        OrderItem orderItem = OrderItem.createOrderItem(item, orderReqDto.getCount());
+
+        List<OrderItem> orderItems = new ArrayList<>();
+        orderItems.add(orderItem);
+
+        Order order = Order.createOrder(member, orderItems);
+
+        orderRepository.save(order);
+
+        return order.getId();
+
+    }
+
+    public List<OrderDto> getAllOrdersByUserEmail(String email) {
+        List<Order> orders = orderRepository.findByMemberEmail(email);
+
+        List<OrderDto> OrderDtos = new ArrayList<>();
+
+        orders.forEach(s -> OrderDtos.add(OrderDto.of(s)));
+
+        return OrderDtos;
+    }
+
+    public OrderItemDto getOrderDetails(Long orderId, String email) {
+        Order order = orderRepository.findById(orderId)
+                .orElseThrow(()-> new IllegalArgumentException("주문 ID 없음 : " + orderId));
+
+        if(!order.getMember().getEmail().equals(email)) {
+            throw new IllegalArgumentException("주문자만 접근 가능함");
+        }
+
+        List<OrderItem> orderItems = order.getOrderItemList();
+
+        if(!orderItems.isEmpty()) {
+            OrderItem orderItem = orderItems.get(0);
+
+            return OrderItemDto.of(orderItem);
+        } else {
+            throw new IllegalArgumentException("주문 아이템이 없음");
+        }
+
+    }
+
+    public void cancelOrder(Long orderId, String email) {
+        Order order = orderRepository.findById(orderId)
+                .orElseThrow(()->new IllegalArgumentException("주문 ID 없음 : " + orderId));
+
+        if(!order.getMember().getEmail().equals(email)) {
+            throw new IllegalArgumentException("취소 권한이 없음");
+        }
+
+        order.cancelOrder();
+        orderRepository.save(order);
+    }
+}

--- a/src/main/java/com/likelion12th/shop/service/UserDetailsService.java
+++ b/src/main/java/com/likelion12th/shop/service/UserDetailsService.java
@@ -1,0 +1,8 @@
+package com.likelion12th.shop.service;
+
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+
+public interface UserDetailService {
+    UserDetails loadUserByUsername(String username) throws UsernameNotFoundException;
+}

--- a/src/main/java/com/likelion12th/shop/service/UserDetailsService.java
+++ b/src/main/java/com/likelion12th/shop/service/UserDetailsService.java
@@ -3,6 +3,6 @@ package com.likelion12th.shop.service;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 
-public interface UserDetailService {
+public interface UserDetailsService {
     UserDetails loadUserByUsername(String username) throws UsernameNotFoundException;
 }

--- a/src/main/resources/templates/main.html
+++ b/src/main/resources/templates/main.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>$Title$</title>
+</head>
+<body>
+$END$
+</body>
+</html>

--- a/src/main/resources/templates/main.html
+++ b/src/main/resources/templates/main.html
@@ -1,10 +1,26 @@
 <!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <title>$Title$</title>
-</head>
-<body>
-$END$
-</body>
+<html xmlns:th="http://www.thymeleaf.org/"
+      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      xmlns:sec="http://www.thymeleaf.org/extras/spring-security"
+      layout:decorate="~{layouts/layout1}">
+
+<div layout:fragment="content">
+    <h1>메인페이지입니다.</h1>
+</div>
+
+<div>
+    <button type="button" class="btn btn-primary" sec:authorize="isAnonymous()" onClick="location.href='/members/login'">로그인</button>
+</div>
+
+<div>
+    <button type="button" class="btn btn-primary" sec:authorize="isAuthenticated()" onClick="location.href='/members/logout'">로그아웃</button>
+</div>
+
+<div>
+    <button type="button" class="btn btn-primary" sec:authorize="isAnonymous()" onClick="location.href='/members/admin'">관리자 회원가입</button>
+</div>
+<div>
+    <button type="button" class="btn btn-primary" sec:authorize="hasRole('ADMIN')" onClick="location.href='/adminpage'">관리자페이지</button>
+</div>
+
 </html>

--- a/src/main/resources/templates/member/adminForm.html
+++ b/src/main/resources/templates/member/adminForm.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org"
+      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      layout:decorate="~{layouts/layout1}">
+
+<head>
+    <meta charset="UTF-8">
+    <title>관리자 등록</title>
+</head>
+<body>
+<h1>관리자 등록</h1>
+    <form action="/members/adminForm" method="post" th:object="${memberFormDto}">
+        <div>
+            <label>이름</label>
+            <input type="text" th:field="*{name}" />
+        </div>
+        <div>
+            <label>이메일</label>
+            <input type="email" th:field="*{email}" />
+        </div>
+        <div>
+            <label>비밀번호</label>
+            <input type="password" th:field="*{password}" />
+        </div>
+        <div>
+            <label>주소</label>
+            <input type="text" th:field="*{address}" />
+        </div>
+        <div>
+            <button type="submit">등록</button>
+        </div>
+    </form>
+</body>
+</html>

--- a/src/main/resources/templates/member/adminForm.html
+++ b/src/main/resources/templates/member/adminForm.html
@@ -5,11 +5,11 @@
 
 <head>
     <meta charset="UTF-8">
-    <title>관리자 등록</title>
+    <title>관리자 회원가입</title>
 </head>
 <body>
-<h1>관리자 등록</h1>
-    <form action="/members/adminForm" method="post" th:object="${memberFormDto}">
+<h1>관리자 회원가입</h1>
+    <form action="/members/admin" method="post" th:object="${memberFormDto}">
         <div>
             <label>이름</label>
             <input type="text" th:field="*{name}" />
@@ -27,8 +27,9 @@
             <input type="text" th:field="*{address}" />
         </div>
         <div>
-            <button type="submit">등록</button>
+            <button type="submit">Submit</button>
         </div>
+        <input type="hidden" name="_csrf" th:value="${_csrf.token}">
     </form>
 </body>
 </html>

--- a/src/main/resources/templates/member/adminPage.html
+++ b/src/main/resources/templates/member/adminPage.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+
+<html xmlns:th="http://www.thymeleaf.org"
+      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      layout:decorate="~{layouts/layout1}">
+
+<head>
+    <title>관리자 페이지</title>
+</head>
+<body>
+    <h1>관리자 외에 접근 불가합니다.</h1>
+</body>
+</html>

--- a/src/main/resources/templates/member/adminPage.html
+++ b/src/main/resources/templates/member/adminPage.html
@@ -2,12 +2,16 @@
 
 <html xmlns:th="http://www.thymeleaf.org"
       xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      xmlns:sec="http://www.thymeleaf.org/extras/spring-security"
       layout:decorate="~{layouts/layout1}">
 
 <head>
+    <meta charset="UTF-8">
     <title>관리자 페이지</title>
 </head>
 <body>
-    <h1>관리자 외에 접근 불가합니다.</h1>
+<sec:authorize access="hasRole('ADMIN')">
+    <p>관리자 외에 접근이 불가합니다.</p>
+</sec:authorize>
 </body>
 </html>

--- a/src/main/resources/templates/member/memberForm.html
+++ b/src/main/resources/templates/member/memberForm.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>$Title$</title>
+</head>
+<body>
+$END$
+</body>
+</html>

--- a/src/main/resources/templates/member/memberForm.html
+++ b/src/main/resources/templates/member/memberForm.html
@@ -1,10 +1,61 @@
 <!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <title>$Title$</title>
-</head>
-<body>
-$END$
-</body>
+<html xmlns:th="http://www.thymeleaf.org"
+      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      layout:decorate="~{layouts/layout1}">
+
+<!-- 사용자 CSS 추가 -->
+<th:block layout:fragment="css">
+    <style>
+        .fieldError {
+            color: #bd2130;
+        }
+    </style>
+</th:block>
+
+<!-- 사용자 스크립트 추가 -->
+<th:block layout:fragment="script">
+
+    <script th:inline="javascript">
+        $(document).ready(function(){
+            var errorMessage = [[${errorMessage}]];
+            if(errorMessage != null){
+                alert(errorMessage);
+            }
+        });
+    </script>
+
+</th:block>
+
+<div layout:fragment="content">
+
+    <form action="/members/new" role="form" method="post"  th:object="${memberFormDto}">
+        <div class="form-group">
+            <label th:for="name">이름</label>
+            <input type="text" th:field="*{name}" class="form-control" placeholder="이름을 입력해주세요">
+            <p th:if="${#fields.hasErrors('name')}" th:errors="*{name}" class="fieldError">Incorrect data</p>
+        </div>
+        <div class="form-group">
+            <label th:for="email">이메일주소</label>
+            <input type="email" th:field="*{email}" class="form-control" placeholder="이메일을 입력해주세요">
+            <p th:if="${#fields.hasErrors('email')}" th:errors="*{email}" class="fieldError">Incorrect data</p>
+        </div>
+        <div class="form-group">
+            <label th:for="password">비밀번호</label>
+            <input type="password" th:field="*{password}" class="form-control" placeholder="비밀번호 입력">
+            <p th:if="${#fields.hasErrors('password')}" th:errors="*{password}" class="fieldError">Incorrect data</p>
+        </div>
+        <div class="form-group">
+            <label th:for="address">주소</label>
+            <input type="text" th:field="*{address}" class="form-control" placeholder="주소를 입력해주세요">
+            <p th:if="${#fields.hasErrors('address')}" th:errors="*{address}" class="fieldError">Incorrect data</p>
+        </div>
+        <div style="text-align: center">
+            <button type="submit" class="btn btn-primary" style="">Submit</button>
+        </div>
+        <input type="hidden" name="_csrf" th:value="${_csrf.token}">
+
+    </form>
+
+</div>
+
 </html>

--- a/src/main/resources/templates/member/memberLoginForm.html
+++ b/src/main/resources/templates/member/memberLoginForm.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>$Title$</title>
+</head>
+<body>
+$END$
+</body>
+</html>

--- a/src/main/resources/templates/member/memberLoginForm.html
+++ b/src/main/resources/templates/member/memberLoginForm.html
@@ -1,10 +1,34 @@
 <!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <title>$Title$</title>
-</head>
-<body>
-$END$
-</body>
+<html xmlns:th="http://www.thymeleaf.org/"
+      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      layout:decorate="~{layouts/layout1}">
+
+<!-- 사용자 CSS 추가 -->
+<th:block layout:fragment="css">
+    <style>
+        .error {
+            color: #bd2130;
+        }
+    </style>
+</th:block>
+
+<div layout:fragment="content">
+
+    <form role="form" method="post" action="/members/login">
+        <div class="form-group">
+            <label th:for="email">이메일주소</label>
+            <input type="email" name="email" class="form-control" placeholder="이메일을 입력해주세요">
+        </div>
+        <div class="form-group">
+            <label th:for="password">비밀번호</label>
+            <input type="password" name="password" id="password" class="form-control" placeholder="비밀번호 입력">
+        </div>
+        <p th:if="${loginErrorMsg}" class="error" th:text="${loginErrorMsg}"></p>
+        <button class="btn btn-primary">로그인</button>
+        <button type="button" class="btn btn-primary" onClick="location.href='/members/new'">회원가입</button>
+        <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
+    </form>
+
+</div>
+
 </html>

--- a/src/test/java/com/likelion12th/shop/entity/MemberServiceTest.java
+++ b/src/test/java/com/likelion12th/shop/entity/MemberServiceTest.java
@@ -1,0 +1,2 @@
+package com.likelion12th.shop.entity;public class MemberServiceTest {
+}

--- a/src/test/java/com/likelion12th/shop/entity/MemberServiceTest.java
+++ b/src/test/java/com/likelion12th/shop/entity/MemberServiceTest.java
@@ -1,2 +1,61 @@
-package com.likelion12th.shop.entity;public class MemberServiceTest {
+package com.likelion12th.shop.entity;
+
+import com.likelion12th.shop.dto.MemberFormDto;
+import com.likelion12th.shop.service.MemberService;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.TestPropertySource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@SpringBootTest
+@Transactional
+@TestPropertySource("classpath:application.properties")
+class MemberServiceTest {
+    @Autowired
+    MemberService memberService;
+
+    @Autowired
+    PasswordEncoder passwordEncoder;
+
+    public Member createMember() {
+        MemberFormDto memberFormDto = new MemberFormDto();
+        memberFormDto.setName("seohee");
+        memberFormDto.setEmail("seohee@naver.com");
+        memberFormDto.setPassword("12345678");
+        memberFormDto.setAddress("서울");
+        Member member = Member.createMember(memberFormDto, passwordEncoder);
+        return member;
+    }
+
+    @Test
+    @DisplayName("회원가입 테스트")
+    public void saveMember() {
+        Member member = this.createMember();
+        Member member1 = memberService.saveMember(member);
+        assertEquals(member.getEmail(), member1.getEmail());
+        assertEquals(member.getName(), member1.getName());
+        assertEquals(member.getRole(), member1.getRole());
+        assertEquals(member.getPassword(), member1.getPassword());
+        assertEquals(member.getAddress(), member1.getAddress());
+    }
+
+    @Test
+    @DisplayName("중복 회원가입 테스트")
+    public void setDuplicateMemberTest() {
+        Member member1 = createMember();
+        Member member2 = createMember();
+        memberService.saveMember(member1);
+
+        Throwable e = assertThrows(IllegalStateException.class, () -> {
+            memberService.saveMember(member2);
+        });
+
+        assertEquals("이미 가입된 회원입니다.", e.getMessage());
+    }
 }

--- a/src/test/java/com/likelion12th/shop/entity/MemberTest.java
+++ b/src/test/java/com/likelion12th/shop/entity/MemberTest.java
@@ -1,2 +1,43 @@
-package com.likelion12th.shop.entity;public class MemberTest {
+package com.likelion12th.shop.entity;
+
+import com.likelion12th.shop.repository.MemberRepository;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.TestPropertySource;
+
+@SpringBootTest
+@Transactional
+@TestPropertySource(locations = "classpath:application.properties")
+public class MemberTest {
+    @Autowired
+    MemberRepository memberRepository;
+
+    @PersistenceContext
+    EntityManager em;
+
+    @Test
+    @DisplayName("Auditing 테스트")
+    @WithMockUser(username = "seohee", roles = "USER")
+    public void auditingTest() {
+        Member member = new Member();
+        Member savedMember = memberRepository.save(member);
+
+        em.flush();
+        em.clear();
+
+        // 방금 생성한 member id로 조회하기(+에러처리)
+        Member member1 = memberRepository.findById(savedMember.getId())
+                .orElseThrow(() -> new RuntimeException("멤버를 찾지 못함."));
+
+        System.out.println("register time: " + member1.getRegTime());
+        System.out.println("update time: " + member1.getUpdateTime());
+        System.out.println("creater: " + member1.getCreatedBy());
+        System.out.println("modifier: " + member1.getModifiedBy());
+    }
 }

--- a/src/test/java/com/likelion12th/shop/entity/MemberTest.java
+++ b/src/test/java/com/likelion12th/shop/entity/MemberTest.java
@@ -1,0 +1,2 @@
+package com.likelion12th.shop.entity;public class MemberTest {
+}

--- a/src/test/java/com/likelion12th/shop/entity/OrderTest.java
+++ b/src/test/java/com/likelion12th/shop/entity/OrderTest.java
@@ -1,0 +1,77 @@
+package com.likelion12th.shop.entity;
+
+import com.likelion12th.shop.constant.OrderStatus;
+import com.likelion12th.shop.constant.itemSellStatus;
+import com.likelion12th.shop.repository.ItemRepository;
+import com.likelion12th.shop.repository.OrderRepository;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityNotFoundException;
+import jakarta.transaction.Transactional;
+import org.aspectj.weaver.ast.Or;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureTestEntityManager;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+@SpringBootTest
+@Transactional
+@TestPropertySource(locations = "classpath:application.properties")
+class OrderTest {
+
+    @Autowired
+    private ItemRepository itemRepository;
+    @Autowired
+    private OrderRepository orderRepository;
+    @Autowired
+    private EntityManager em;
+
+    public Item createItem() {
+        Item item = new Item();
+        item.setItemName("테스트 상품");
+        item.setPrice(10000);
+        item.setItemDetail("테스트 상품 상세 설명");
+        item.setItemSellStatus(itemSellStatus.InStock);
+        item.setStock(100);
+        item.setCreatedBy(LocalDateTime.now());
+        item.setModifiedBy(LocalDateTime.now());
+
+        return item;
+    }
+
+    @Test
+    @DisplayName("영속성 전이 테스트")
+    public void cascadeTest() {
+
+        Order order = new Order();
+
+        for(int i=0; i<3; i++) {
+            Item item = this.createItem();
+            itemRepository.save(item);
+
+            OrderItem orderItem = new OrderItem();
+            orderItem.setItem(item);
+            orderItem.setCount(10);
+            orderItem.setOrderPrice(1000);
+            orderItem.setCreatedBy(LocalDateTime.now());
+            orderItem.setModifiedBy(LocalDateTime.now());
+
+            //주문 상품에 추가 - add 사용
+            order.getOrderItems().add(orderItem);
+        }
+
+
+        orderRepository.saveAndFlush(order);
+        em.clear();
+
+        Order savedOrder = orderRepository.findById(order.getId())
+        .orElseThrow(EntityNotFoundException::new);
+        assertEquals(3, order.getOrderItems().size());
+    }
+
+}

--- a/src/test/java/com/likelion12th/shop/entity/OrderTest.java
+++ b/src/test/java/com/likelion12th/shop/entity/OrderTest.java
@@ -3,9 +3,14 @@ package com.likelion12th.shop.entity;
 import com.likelion12th.shop.constant.OrderStatus;
 import com.likelion12th.shop.constant.itemSellStatus;
 import com.likelion12th.shop.repository.ItemRepository;
+import com.likelion12th.shop.repository.MemberRepository;
+import com.likelion12th.shop.repository.OrderItemRepository;
 import com.likelion12th.shop.repository.OrderRepository;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityNotFoundException;
+import jakarta.persistence.PersistenceContext;
 import jakarta.transaction.Transactional;
 import org.aspectj.weaver.ast.Or;
 import org.junit.jupiter.api.DisplayName;
@@ -15,6 +20,7 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureTestEnti
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.TestPropertySource;
 
+import javax.swing.plaf.synth.SynthUI;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -29,7 +35,15 @@ class OrderTest {
     @Autowired
     private OrderRepository orderRepository;
     @Autowired
+    @PersistenceContext
     private EntityManager em;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private OrderItemRepository orderItemRepository;
+
 
     public Item createItem() {
         Item item = new Item();
@@ -43,6 +57,39 @@ class OrderTest {
 
         return item;
     }
+
+    public Order createOrder() {
+        Order order = new Order();
+
+        for(int i=0; i<3; i++) {
+            // item 생성
+            Item item = createItem();
+            itemRepository.save(item);
+
+            // orderItem 생성
+            OrderItem orderItem = new OrderItem();
+            orderItem.setItem(item);
+            orderItem.setOrderPrice(10000);
+            orderItem.setCount(1);
+            orderItem.setOrder(order);
+            orderItem.setCreatedBy(LocalDateTime.now());
+            orderItem.setModifiedBy(LocalDateTime.now());
+
+            // order에 주문 상품 추가
+            order.getOrderItemList().add(orderItem);
+        }
+
+        // 회원 생성
+        Member member = new Member();
+        memberRepository.save(member);
+
+        // 주문 생성
+        order.setMember(member);
+        orderRepository.save(order);
+
+        return order;
+    }
+
 
     @Test
     @DisplayName("영속성 전이 테스트")
@@ -61,8 +108,8 @@ class OrderTest {
             orderItem.setCreatedBy(LocalDateTime.now());
             orderItem.setModifiedBy(LocalDateTime.now());
 
-            //주문 상품에 추가 - add 사용
-            order.getOrderItems().add(orderItem);
+            //주문 상품에 추가
+            order.getOrderItemList().add(orderItem);
         }
 
 
@@ -71,7 +118,31 @@ class OrderTest {
 
         Order savedOrder = orderRepository.findById(order.getId())
         .orElseThrow(EntityNotFoundException::new);
-        assertEquals(3, order.getOrderItems().size());
+        assertEquals(3, order.getOrderItemList().size());
     }
 
+    @Test
+    @DisplayName("고아객체 제거 테스트")
+    public void orphanRemovalTest() {
+        Order order = this.createOrder();
+        order.getOrderItemList().remove(0);
+        em.flush();
+    }
+
+    @Test
+    @DisplayName("지연 로딩 테스트")
+    public void lazyLoadingTest() {
+        Order order = this.createOrder();
+        Long orderItemId = order.getOrderItemList().get(0).getId();
+        em.flush();
+        em.clear();
+
+        //id로 주문 상품 조회
+        OrderItem orderItem = orderItemRepository.findById(orderItemId).orElseThrow(EntityNotFoundException::new);
+
+        System.out.println("Order class: " + orderItem.getOrder().getClass());
+        System.out.println("====================================================");
+        orderItem.getOrder().getOrderDate();
+        System.out.println("====================================================");
+    }
 }

--- a/src/test/java/com/likelion12th/shop/entity/OrderTest.java
+++ b/src/test/java/com/likelion12th/shop/entity/OrderTest.java
@@ -1,28 +1,21 @@
 package com.likelion12th.shop.entity;
 
-import com.likelion12th.shop.constant.OrderStatus;
-import com.likelion12th.shop.constant.itemSellStatus;
+import com.likelion12th.shop.constant.ItemSellStatus;
 import com.likelion12th.shop.repository.ItemRepository;
 import com.likelion12th.shop.repository.MemberRepository;
 import com.likelion12th.shop.repository.OrderItemRepository;
 import com.likelion12th.shop.repository.OrderRepository;
-import com.querydsl.jpa.impl.JPAQuery;
-import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityNotFoundException;
 import jakarta.persistence.PersistenceContext;
 import jakarta.transaction.Transactional;
-import org.aspectj.weaver.ast.Or;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureTestEntityManager;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.TestPropertySource;
 
-import javax.swing.plaf.synth.SynthUI;
 import java.time.LocalDateTime;
-import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 @SpringBootTest
@@ -50,7 +43,7 @@ class OrderTest {
         item.setItemName("테스트 상품");
         item.setPrice(10000);
         item.setItemDetail("테스트 상품 상세 설명");
-        item.setItemSellStatus(itemSellStatus.InStock);
+        item.setItemSellStatus(ItemSellStatus.SELL);
         item.setStock(100);
         item.setCreatedBy(LocalDateTime.now());
         item.setModifiedBy(LocalDateTime.now());

--- a/src/test/java/com/likelion12th/shop/repository/ItemRepositoryTest.java
+++ b/src/test/java/com/likelion12th/shop/repository/ItemRepositoryTest.java
@@ -1,7 +1,6 @@
 package com.likelion12th.shop.repository;
 
-import com.likelion12th.shop.constant.OrderStatus;
-import com.likelion12th.shop.constant.itemSellStatus;
+import com.likelion12th.shop.constant.ItemSellStatus;
 import com.likelion12th.shop.entity.*;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -11,14 +10,11 @@ import jakarta.transaction.Transactional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.TestPropertySource;
 
 import java.time.LocalDateTime;
 import java.util.List;
-
-import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
 @Transactional
@@ -37,7 +33,7 @@ class ItemRepositoryTest {
         item.setItemName("테스트 상품");
         item.setPrice(1000);
         item.setItemDetail("테스트 상품 상세 설명");
-        item.setItemSellStatus(itemSellStatus.InStock);
+        item.setItemSellStatus(ItemSellStatus.SELL);
         item.setStock(100);
         item.setCreatedBy(LocalDateTime.now());
         item.setModifiedBy(LocalDateTime.now());
@@ -52,7 +48,7 @@ class ItemRepositoryTest {
             item.setItemName("테스트 상품 " + i);
             item.setPrice(1000 + i);
             item.setItemDetail("테스트 상품 상세 설명 " + i);
-            item.setItemSellStatus(itemSellStatus.InStock);
+            item.setItemSellStatus(ItemSellStatus.SELL);
             item.setStock(100);
             item.setCreatedBy(LocalDateTime.now());
             item.setModifiedBy(LocalDateTime.now());
@@ -107,7 +103,7 @@ class ItemRepositoryTest {
         QItem qItem = QItem.item;
 
         JPAQuery<Item> query = queryFactory.selectFrom(qItem)
-                .where(qItem.itemSellStatus.eq(itemSellStatus.InStock))
+                .where(qItem.ItemSellStatus.eq(ItemSellStatus.SELL))
                 .where(qItem.itemDetail.like("%" + "테스트 상품 상세 설명" + "%"))
                 .orderBy(qItem.price.desc());
 

--- a/src/test/java/com/likelion12th/shop/repository/ItemRepositoryTest.java
+++ b/src/test/java/com/likelion12th/shop/repository/ItemRepositoryTest.java
@@ -1,0 +1,91 @@
+package com.likelion12th.shop.repository;
+
+import com.likelion12th.shop.constant.itemSellStatus;
+import com.likelion12th.shop.entity.Item;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@Transactional
+@TestPropertySource(locations = "classpath:application.properties")
+class ItemRepositoryTest {
+    @Autowired
+    private ItemRepository itemRepository;
+
+    @Test
+    @DisplayName("상품 저장 테스트")
+    public void createItemTest() {
+        Item item = new Item();
+        item.setItemName("테스트 상품");
+        item.setPrice(1000);
+        item.setItemDetail("테스트 상품 상세 설명");
+        item.setItemSellStatus(itemSellStatus.InStock);
+        item.setStock(100);
+        item.setCreatedBy(LocalDateTime.now());
+        item.setModifiedBy(LocalDateTime.now());
+
+        Item savedItem = itemRepository.save(item);
+        System.out.println(savedItem.toString());
+    }
+
+    public void createItemList() {
+        for (int i = 1; i <= 10; i++) {
+            Item item = new Item();
+            item.setItemName("테스트 상품 " + i);
+            item.setPrice(1000 + i);
+            item.setItemDetail("테스트 상품 상세 설명 " + i);
+            item.setItemSellStatus(itemSellStatus.InStock);
+            item.setStock(100);
+            item.setCreatedBy(LocalDateTime.now());
+            item.setModifiedBy(LocalDateTime.now());
+
+            Item savedItem = itemRepository.save(item);
+            System.out.println(savedItem.toString());
+
+            Item savedcreateItem = itemRepository.save(item);
+            System.out.println(savedItem.toString());
+        }
+    }
+
+    @Test
+    @DisplayName("상품명 조회 테스트")
+    public void findByItemNameTest() {
+        this.createItemList();
+        List<Item> itemList = itemRepository.findByItemName("테스트 상품 1");
+        for (int i = 1; i <= itemList.size(); i++) {
+            System.out.println(itemList.toString());
+        }
+    }
+
+    @Test
+    @DisplayName("가격 내림차순 조회 테스트")
+    public void findByPriceLessThanOrderByPriceDescTest() {
+        this.createItemList();
+
+        List<Item> itemList = itemRepository.findByPriceLessThanOrderByPriceDesc(10005);
+        for (Item item : itemList) {
+            System.out.println(item.toString());
+        }
+    }
+
+    @Test
+    @DisplayName("@Query를 이용한 상품 조회 테스트")
+    public void findByItemDetailTest() {
+        this.createItemList();
+
+        List<Item> itemList = itemRepository.findByItemDetail("테스트 상품 상세 설명");
+        for (Item item : itemList) {
+            System.out.println(item.toString());
+        }
+    }
+}

--- a/src/test/java/com/likelion12th/shop/repository/ItemRepositoryTest.java
+++ b/src/test/java/com/likelion12th/shop/repository/ItemRepositoryTest.java
@@ -1,7 +1,12 @@
 package com.likelion12th.shop.repository;
 
+import com.likelion12th.shop.constant.OrderStatus;
 import com.likelion12th.shop.constant.itemSellStatus;
-import com.likelion12th.shop.entity.Item;
+import com.likelion12th.shop.entity.*;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
 import jakarta.transaction.Transactional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -21,6 +26,9 @@ import static org.junit.jupiter.api.Assertions.*;
 class ItemRepositoryTest {
     @Autowired
     private ItemRepository itemRepository;
+
+    @PersistenceContext
+    EntityManager em;
 
     @Test
     @DisplayName("상품 저장 테스트")
@@ -57,6 +65,8 @@ class ItemRepositoryTest {
         }
     }
 
+
+
     @Test
     @DisplayName("상품명 조회 테스트")
     public void findByItemNameTest() {
@@ -88,4 +98,25 @@ class ItemRepositoryTest {
             System.out.println(item.toString());
         }
     }
+
+    @Test
+    @DisplayName("Querydsl 조회 테스트")
+    public void queryDslTest() {
+        this.createItemList();
+        JPAQueryFactory queryFactory = new JPAQueryFactory(em);
+        QItem qItem = QItem.item;
+
+        JPAQuery<Item> query = queryFactory.selectFrom(qItem)
+                .where(qItem.itemSellStatus.eq(itemSellStatus.InStock))
+                .where(qItem.itemDetail.like("%" + "테스트 상품 상세 설명" + "%"))
+                .orderBy(qItem.price.desc());
+
+        List<Item> itemList = query.fetch();
+
+        for(Item item : itemList) {
+            System.out.println(item.toString());
+        }
+    }
+
 }
+

--- a/src/test/java/com/likelion12th/shop/repository/MemberRepositoryTest.java
+++ b/src/test/java/com/likelion12th/shop/repository/MemberRepositoryTest.java
@@ -1,0 +1,32 @@
+package com.likelion12th.shop.repository;
+
+import com.likelion12th.shop.entity.Member;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@Transactional
+@TestPropertySource(locations = "classpath:application.properties")
+public class MemberRepositoryTest {
+    @Autowired
+    MemberRepository memberRepository;
+
+    @Test
+    @DisplayName("회원가입 테스트")
+    public void createMemberTest() {
+        Member member = new Member();
+        member.setName("엄서희");
+        member.setEmail("seohee030128@naver.com");
+        member.setPassword("seohee");
+        member.setAddress("강남구");
+
+        Member savedMember = memberRepository.save(member);
+        System.out.println(savedMember.toString());
+    }
+}

--- a/src/test/java/com/likelion12th/shop/repository/OrderRepositoryTest.java
+++ b/src/test/java/com/likelion12th/shop/repository/OrderRepositoryTest.java
@@ -1,0 +1,7 @@
+package com.likelion12th.shop.repository;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class OrderRepositoryTest {
+
+}

--- a/src/test/java/com/likelion12th/shop/repository/PaymentRepositoryTest.java
+++ b/src/test/java/com/likelion12th/shop/repository/PaymentRepositoryTest.java
@@ -1,0 +1,33 @@
+package com.likelion12th.shop.repository;
+
+import com.likelion12th.shop.entity.Payment;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+
+import static org.junit.jupiter.api.Assertions.*;
+@SpringBootTest
+@Transactional
+@TestPropertySource(locations = "classpath:application.properties")
+class PaymentRepositoryTest {
+
+    @Autowired
+    PaymentRepository paymentRepository;
+
+    @Test
+    @DisplayName("결제 테스트")
+    public void createPaymentTest() {
+        Payment payment = new Payment();
+        payment.setAmount(2);
+        payment.setPrice(25000);
+        payment.setPaymentMethod("creditcard");
+        payment.setCustomerId("seohee");
+
+        Payment savedPayment = paymentRepository.save(payment);
+        System.out.println(savedPayment.toString());
+    }
+
+}


### PR DESCRIPTION
메인 페이지에서 관리자 회원가입 버튼을 누르면 관리자 회원가입 폼으로 넘어간다.
관리자 회원가입 시 메인 페이지로 다시 넘어간 후 관리자 아이디와 비밀번호로 로그인 시 관리자 페이지로 접근 가능하다.

templates/member 경로에 adminForm.html(관리자 회원가입)과 adminPage.html을 설정했다.
Member 엔티티에 createAdminMember을 생성해 멤버 테이블에서 Role을 ADMIN으로 set할 수 있도록 했다.
인터페이스 AccessDeniedHandle를 CustomAccessDeniedHandler로 구현하고 securityConfig에서 .requestMatchers("/admin/**").hasRole("ADMIN")로 지정해 admin이하의 주소는 관리자 권한을 가진 사람만 볼 수 있도록 했다.
main.html에서 sec:authorize="hasRole('ADMIN')" onClick="location.href='/adminpage'"로 지정해 관리자 페이지에 관리자 권한 제어를 적용했다.